### PR TITLE
Improve error and success event messages for BucketClaim/BucketAccess

### DIFF
--- a/iam/s3_access_policy.go
+++ b/iam/s3_access_policy.go
@@ -35,9 +35,16 @@ func NewS3Policy(policyName, bucketName, systemId string, client *sdk.APIClient,
 
 // Returns the access policy by name(passed with s3policy instance)
 func (p *s3policy) GetS3AccessPolicy() (*sdk.AccessPolicy, error) {
+	maskedName := utils.MaskName(p.name)
 	ap, r, err := p.client.ObjectstoreIdentitiesAPI.DeviceType7GetAccessPolicyById(p.context, p.systemId, p.name).Execute()
-	if err == nil && r.StatusCode != http.StatusOK {
-		err = fmt.Errorf("request failed while fetching s3 access policy %s, err : %v", utils.MaskName(p.name), r)
+	if err != nil {
+		if r != nil && r.StatusCode == http.StatusNotFound {
+			return ap, err
+		}
+		return ap, utils.FormatIAMError(fmt.Sprintf("failed to fetch s3 access policy %s", maskedName), err)
+	}
+	if r.StatusCode != http.StatusOK {
+		err = fmt.Errorf("failed to fetch s3 access policy %s (HTTP %d): %s", maskedName, r.StatusCode, readResponseBody(r))
 	}
 	return ap, err
 }
@@ -47,7 +54,7 @@ func (p *s3policy) PolicyExists() (bool, error) {
 	log := utils.GetLoggerFromContext(p.context)
 	ap, r, err := p.client.ObjectstoreIdentitiesAPI.DeviceType7GetAccessPolicyById(p.context, p.systemId, p.name).Execute()
 	if err != nil && r != nil && r.StatusCode == http.StatusNotFound {
-		e, body := getResponseErrorCode(p.context, r)
+		e, body := getResponseErrorCode(r)
 		if e.GetErrorCode() == string(ERR_RESOURCE_NOT_FOUND) {
 			return false, nil
 		}
@@ -71,14 +78,18 @@ func (p *s3policy) PolicyHasFullBucketAccess() (bool, error) {
 // Creates an access policy with the passed name in DSCC
 // returns the task details created for this process
 func (p *s3policy) CreateS3AccessPolicy() (*sdk.TaskResponseUi, error) {
+	maskedName := utils.MaskName(p.name)
 
 	policyStatement := p.formFullAccessRuleForBucket()
 
 	createAccessPolicyBody := *sdk.NewCreateAccessPolicyBody(p.name, []sdk.PolicyStatementInput{policyStatement}, DSCC_POLICY_VERSION)
 	taskUI, r, err := p.client.ObjectstoreIdentitiesAPI.DeviceType7CreateAccessPolicy(p.context, p.systemId).
 		CreateAccessPolicyBody(createAccessPolicyBody).Execute()
-	if err == nil && (r.StatusCode != http.StatusAccepted || taskUI.GetStatus() != string(SUBMITTED)) {
-		err = fmt.Errorf("request failed while creating s3 access policy %s, err: %v", utils.MaskName(p.name), r)
+	if err != nil {
+		return taskUI, utils.FormatIAMError(fmt.Sprintf("failed to create s3 access policy %s", maskedName), err)
+	}
+	if r.StatusCode != http.StatusAccepted || taskUI.GetStatus() != string(SUBMITTED) {
+		err = fmt.Errorf("failed to create s3 access policy %s (HTTP %d): %s", maskedName, r.StatusCode, readResponseBody(r))
 	}
 	return taskUI, err
 }
@@ -87,12 +98,16 @@ func (p *s3policy) CreateS3AccessPolicy() (*sdk.TaskResponseUi, error) {
 // returns the task details created for this process
 // returns an error, if the policy is not existing under DSCC
 func (p *s3policy) UpdateS3AccessPolicy() (*sdk.TaskResponseUi, error) {
+	maskedName := utils.MaskName(p.name)
 	policyStatement := p.formFullAccessRuleForBucket()
 	updateAccessPolicyBody := *sdk.NewUpdateAccessPolicyBody([]sdk.PolicyStatementInput{policyStatement}, DSCC_POLICY_VERSION)
 	taskUI, r, err := p.client.ObjectstoreIdentitiesAPI.DeviceType7UpdateAccessPolicyById(p.context, p.systemId, p.name).
 		UpdateAccessPolicyBody(updateAccessPolicyBody).Execute()
-	if err == nil && (r.StatusCode != http.StatusAccepted || taskUI.GetStatus() != string(SUBMITTED)) {
-		err = fmt.Errorf("request failed while updating s3 access policy %s, err: %v", utils.MaskName(p.name), r)
+	if err != nil {
+		return taskUI, utils.FormatIAMError(fmt.Sprintf("failed to update s3 access policy %s", maskedName), err)
+	}
+	if r.StatusCode != http.StatusAccepted || taskUI.GetStatus() != string(SUBMITTED) {
+		err = fmt.Errorf("failed to update s3 access policy %s (HTTP %d): %s", maskedName, r.StatusCode, readResponseBody(r))
 	}
 	return taskUI, err
 }
@@ -101,10 +116,14 @@ func (p *s3policy) UpdateS3AccessPolicy() (*sdk.TaskResponseUi, error) {
 // returns the task details created for this process
 // returns an error, if the policy is not existing under DSCC
 func (p *s3policy) DeleteS3AccessPolicy() (*sdk.TaskResponseUi, error) {
+	maskedName := utils.MaskName(p.name)
 	taskUI, r, err := p.client.ObjectstoreIdentitiesAPI.DeviceType7DeleteAccessPolicyById(p.context, p.systemId, p.name).Execute()
 
-	if err == nil && (r.StatusCode != http.StatusAccepted || taskUI.GetStatus() != string(SUBMITTED)) {
-		err = fmt.Errorf("request failed while deleting s3 access policy %s, err: %v", utils.MaskName(p.name), r)
+	if err != nil {
+		return taskUI, utils.FormatIAMError(fmt.Sprintf("failed to delete s3 access policy %s", maskedName), err)
+	}
+	if r.StatusCode != http.StatusAccepted || taskUI.GetStatus() != string(SUBMITTED) {
+		err = fmt.Errorf("failed to delete s3 access policy %s (HTTP %d): %s", maskedName, r.StatusCode, readResponseBody(r))
 	}
 	return taskUI, err
 }

--- a/iam/s3_user.go
+++ b/iam/s3_user.go
@@ -32,9 +32,13 @@ func NewS3User(userName, systemId string, client *sdk.APIClient, context context
 
 // Returns the access policy by name(passed with s3policy instance)
 func (u *s3user) GetS3User() (*sdk.UserListDetails, error) {
+	maskedName := utils.MaskName(u.name)
 	user, r, err := u.client.ObjectstoreIdentitiesAPI.DeviceType7GetSingleUser(u.context, u.systemId, u.name).Execute()
-	if err == nil && r.StatusCode != http.StatusOK {
-		err = fmt.Errorf("request failed while fetching s3 user %s, err: %v", u.name, r)
+	if err != nil {
+		return user, utils.FormatIAMError(fmt.Sprintf("failed to fetch s3 user %s", maskedName), err)
+	}
+	if r.StatusCode != http.StatusOK {
+		err = fmt.Errorf("failed to fetch s3 user %s (HTTP %d): %s", maskedName, r.StatusCode, readResponseBody(r))
 	}
 	return user, err
 }
@@ -44,7 +48,7 @@ func (u *s3user) UserExists() (bool, error) {
 	log := utils.GetLoggerFromContext(u.context)
 	ap, r, err := u.client.ObjectstoreIdentitiesAPI.DeviceType7GetSingleUser(u.context, u.systemId, u.name).Execute()
 	if err != nil && r != nil && r.StatusCode == http.StatusNotFound {
-		e, body := getResponseErrorCode(u.context, r)
+		e, body := getResponseErrorCode(r)
 		if e.GetErrorCode() == string(ERR_RESOURCE_NOT_FOUND) {
 			return false, nil
 		}
@@ -53,7 +57,7 @@ func (u *s3user) UserExists() (bool, error) {
 	} else if ap != nil && err == nil {
 		return true, nil
 	} else if r != nil {
-		e, body := getResponseErrorCode(u.context, r)
+		e, body := getResponseErrorCode(r)
 		if e.GetErrorCode() == string(DOWNSTREAM_SERVICE_ERROR) {
 			log.Error(err, "Downstream service error from DSCC;"+
 				" verify GLCP credentials, workspace in mounted"+
@@ -70,18 +74,14 @@ func (u *s3user) UserExists() (bool, error) {
 // Creates a user with the passed name in DSCC
 // returns the new secret key of the user
 func (u *s3user) CreateS3User() (string, error) {
-	log := utils.GetLoggerFromContext(u.context)
+	maskedName := utils.MaskName(u.name)
 	userDetails := *sdk.NewUserDetails(u.name)
 	resp, r, err := u.client.ObjectstoreIdentitiesAPI.DeviceType7CreateUser(u.context, u.systemId).
 		UserDetails(userDetails).Execute()
 	if err != nil {
-		if r != nil {
-			_, body := getResponseErrorCode(u.context, r)
-			log.Error(err, "Failed to create S3 user in DSCC", "user", utils.MaskName(u.name), "statusCode", r.StatusCode, "status", r.Status, "response body", body)
-		}
-		return "", err
+		return "", utils.FormatIAMError(fmt.Sprintf("failed to create s3 user %s", maskedName), err)
 	} else if r.StatusCode != http.StatusCreated {
-		return "", fmt.Errorf("request failed while creating s3 user %s, err: %v", utils.MaskName(u.name), r)
+		return "", fmt.Errorf("failed to create s3 user %s (HTTP %d): %s", maskedName, r.StatusCode, readResponseBody(r))
 	}
 	return resp.GetSecretKey(), nil
 }
@@ -90,12 +90,13 @@ func (u *s3user) CreateS3User() (string, error) {
 // returns the new secret key of the user
 // returns an error, if the user is not existing under DSCC
 func (u *s3user) ResetPassword() (string, error) {
+	maskedName := utils.MaskName(u.name)
 	userDetails := *sdk.NewUserDetailsEdit(true)
 	resp, r, err := u.client.ObjectstoreIdentitiesAPI.DeviceType7EditUser(u.context, u.systemId, u.name).UserDetailsEdit(userDetails).Execute()
 	if err != nil {
-		return "", err
+		return "", utils.FormatIAMError(fmt.Sprintf("failed to reset s3 user %s password", maskedName), err)
 	} else if r.StatusCode != http.StatusCreated {
-		return "", fmt.Errorf("request failed while resetting s3 user %s password, err: %v", utils.MaskName(u.name), r)
+		return "", fmt.Errorf("failed to reset s3 user %s password (HTTP %d): %s", maskedName, r.StatusCode, readResponseBody(r))
 	}
 	return resp.GetSecretKey(), nil
 }
@@ -104,11 +105,15 @@ func (u *s3user) ResetPassword() (string, error) {
 // returns the task details created for this process
 // returns an error, if the user or policy is not existing under DSCC
 func (u *s3user) ApplyPolicy(policies []string) (*sdk.TaskResponseUi, error) {
+	maskedName := utils.MaskName(u.name)
 	policy := *sdk.NewApplyPolicy(u.name, policies, string(USER))
 
 	taskUI, r, err := u.client.ObjectstoreIdentitiesAPI.ApplyPolicy(u.context, u.systemId).ApplyPolicy(policy).Execute()
-	if err == nil && (r.StatusCode != http.StatusAccepted || taskUI.GetStatus() != string(SUBMITTED)) {
-		err = fmt.Errorf("request failed while applying policies %v, to the user %s, err: %v", policies, utils.MaskName(u.name), r)
+	if err != nil {
+		return taskUI, utils.FormatIAMError(fmt.Sprintf("failed to apply policies to user %s", maskedName), err)
+	}
+	if r.StatusCode != http.StatusAccepted || taskUI.GetStatus() != string(SUBMITTED) {
+		err = fmt.Errorf("failed to apply policies to user %s (HTTP %d): %s", maskedName, r.StatusCode, readResponseBody(r))
 	}
 	return taskUI, err
 }
@@ -117,25 +122,36 @@ func (u *s3user) ApplyPolicy(policies []string) (*sdk.TaskResponseUi, error) {
 // returns the task details created for this process
 // returns an error, if the user is not existing under DSCC
 func (u *s3user) DeleteS3User() (*sdk.TaskResponseUi, error) {
+	maskedName := utils.MaskName(u.name)
 	taskUI, r, err := u.client.ObjectstoreIdentitiesAPI.DeviceType7DeleteUserById(u.context, u.systemId, u.name).Execute()
-	if err == nil && (r.StatusCode != http.StatusAccepted || taskUI.GetStatus() != string(SUBMITTED)) {
-		err = fmt.Errorf("request failed while delete s3 user %s, err: %v", utils.MaskName(u.name), r)
+	if err != nil {
+		return taskUI, utils.FormatIAMError(fmt.Sprintf("failed to delete s3 user %s", maskedName), err)
+	}
+	if r.StatusCode != http.StatusAccepted || taskUI.GetStatus() != string(SUBMITTED) {
+		err = fmt.Errorf("failed to delete s3 user %s (HTTP %d): %s", maskedName, r.StatusCode, readResponseBody(r))
 	}
 	return taskUI, err
 }
 
-func getResponseErrorCode(ctx context.Context, r *http.Response) (sdk.InternalErrorResponseUi, string) {
-	log := utils.GetLoggerFromContext(ctx)
+// readResponseBody reads the HTTP response body and returns a parsed,
+// human-readable error string using ParseIAMErrorResponse.
+// Returns an empty string if the body cannot be read.
+func readResponseBody(r *http.Response) string {
+	if r == nil || r.Body == nil {
+		return ""
+	}
+	_, body := getResponseErrorCode(r)
+	return body
+}
+
+func getResponseErrorCode(r *http.Response) (sdk.InternalErrorResponseUi, string) {
 	var b sdk.InternalErrorResponseUi
 	defer r.Body.Close()
 	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		log.Error(err, "Unable to retrieve body from http response")
+	if err != nil || len(body) == 0 {
 		return b, ""
 	}
-	if err = json.Unmarshal(body, &b); err != nil {
-		log.Error(err, "Failed to unmarshal body from, %s", string(body)[:])
-		return b, string(body)[:]
-	}
-	return b, string(body)[:]
+	// Best-effort unmarshal into structured error; ignore failures
+	_ = json.Unmarshal(body, &b)
+	return b, utils.ParseIAMErrorResponse(body)
 }

--- a/iam/tasks.go
+++ b/iam/tasks.go
@@ -32,8 +32,11 @@ func NewTask(taskId, systemId string, client *sdk.APIClient, ctx context.Context
 // Returns the running task by id (passed with s3policy instance)
 func (t *task) GetTask() (*sdk.Task, error) {
 	task, r, err := t.client.TasksAPI.GetTask(t.context, t.taskId).Execute()
-	if err == nil && r.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("request failed while fetching taskId %s, err: %v", t.taskId, r)
+	if err != nil {
+		return task, utils.FormatIAMError(fmt.Sprintf("failed to fetch task %s", t.taskId), err)
+	}
+	if r.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch task %s (HTTP %d)", t.taskId, r.StatusCode)
 	}
 	return task, err
 }

--- a/servers/provisioner/provisioner.go
+++ b/servers/provisioner/provisioner.go
@@ -98,7 +98,7 @@ func (s *Server) DriverCreateBucket(ctx context.Context, req *cosi.DriverCreateB
 
 	// Attempt bucket creation (idempotent: handle "already exists" inside CreateBucket)
 	if err = s3c.CreateBucket(ctx, bucketName, bucketReq); err != nil {
-		return nil, utils.ToGRPCStatusError("failed to create bucket", err)
+		return nil, utils.ToGRPCStatusError("Bucket creation failed", err)
 	}
 
 	// If locking is enabled, set object lock configuration
@@ -106,7 +106,7 @@ func (s *Server) DriverCreateBucket(ctx context.Context, req *cosi.DriverCreateB
 		err = s3c.SetObjectLockConfiguration(ctx, bucketName, string(bucketReq.Locking), string(bucketReq.RetentionMode), bucketReq.ObjectLockDays, bucketReq.ObjectLockYears)
 		if err != nil {
 			s.log.Error(err, "failed to set object lock configuration")
-			return nil, utils.ToGRPCStatusError("failed to set object lock configuration", err)
+			return nil, utils.ToGRPCStatusError("Bucket object lock configuration failed", err)
 		}
 	}
 
@@ -115,13 +115,13 @@ func (s *Server) DriverCreateBucket(ctx context.Context, req *cosi.DriverCreateB
 		err = s3c.PutBucketTagging(ctx, bucketName, tags)
 		if err != nil {
 			s.log.Error(err, "failed to set bucket tags")
-			return nil, utils.ToGRPCStatusError("failed to set bucket tags", err)
+			return nil, utils.ToGRPCStatusError("Bucket tagging failed", err)
 		}
 	}
 
 	return &cosi.DriverCreateBucketResponse{
 		BucketId: bucketName,
-	}, status.Error(codes.OK, "Bucket creation successfully completed")
+	}, status.Error(codes.OK, fmt.Sprintf("Bucket '%s' created successfully", bucketName))
 }
 
 // DriverDeleteBucket handles the deletion of a bucket in the backend.
@@ -137,7 +137,7 @@ func (s *Server) DriverDeleteBucket(ctx context.Context, req *cosi.DriverDeleteB
 	bucket, err := s.BucketClientset.ObjectstorageV1alpha1().Buckets().Get(ctx, bucketName, metav1.GetOptions{})
 	if err != nil {
 		s.log.Error(err, "failed to get bucket object", "bucketName", bucketName)
-		return nil, utils.ToGRPCStatusError(fmt.Sprintf("failed to get bucket: %s", bucketName), err)
+		return nil, utils.ToGRPCStatusError(fmt.Sprintf("Bucket deletion failed: unable to get bucket '%s'", bucketName), err)
 	}
 	// Get the parameters from the spec of the bucket
 	param := bucket.Spec.Parameters
@@ -150,10 +150,10 @@ func (s *Server) DriverDeleteBucket(ctx context.Context, req *cosi.DriverDeleteB
 
 	// Attempt bucket deletion
 	if err = s3c.DeleteBucket(ctx, bucketName); err != nil {
-		return nil, utils.ToGRPCStatusError("failed to delete bucket", err)
+		return nil, utils.ToGRPCStatusError("Bucket deletion failed", err)
 	}
 
-	return &cosi.DriverDeleteBucketResponse{}, status.Error(codes.OK, "Bucket deletion successfully completed")
+	return &cosi.DriverDeleteBucketResponse{}, status.Error(codes.OK, fmt.Sprintf("Bucket '%s' deleted successfully", bucketName))
 }
 
 // DriverGrantBucketAccess grants access to a bucket for a specific account.
@@ -173,7 +173,7 @@ func (s *Server) DriverGrantBucketAccess(ctx context.Context, req *cosi.DriverGr
 		return &cosi.DriverGrantBucketAccessResponse{
 			AccountId:   maskedBucketAccessName,
 			Credentials: nil,
-		}, utils.ToGRPCStatusError("Unsupported authenticationType", err)
+		}, utils.ToGRPCStatusError("Bucket access grant failed: unsupported authenticationType", err)
 	}
 
 	param := req.Parameters
@@ -184,7 +184,7 @@ func (s *Server) DriverGrantBucketAccess(ctx context.Context, req *cosi.DriverGr
 	name, namespace, err := getSecretNameAndNamespace(ctx, param)
 
 	if err != nil {
-		eMsg = "error while retrieving details of secret used in bucket access class"
+		eMsg = "Bucket access grant failed: unable to retrieve secret details from BucketAccessClass"
 		s.log.Error(err, eMsg)
 		return &cosi.DriverGrantBucketAccessResponse{
 			AccountId:   maskedBucketAccessName,
@@ -194,7 +194,7 @@ func (s *Server) DriverGrantBucketAccess(ctx context.Context, req *cosi.DriverGr
 
 	secret, err := getSecret(s.K8sClientset, ctx, name, namespace)
 	if err != nil || secret == nil || secret.Data == nil || len(secret.Data) == 0 {
-		eMsg = fmt.Sprintf("error while fetching secret %s used in bucket access class", name)
+		eMsg = fmt.Sprintf("Bucket access grant failed: unable to fetch secret '%s'", name)
 		s.log.Error(err, eMsg)
 		return &cosi.DriverGrantBucketAccessResponse{
 			AccountId:   maskedBucketAccessName,
@@ -204,7 +204,7 @@ func (s *Server) DriverGrantBucketAccess(ctx context.Context, req *cosi.DriverGr
 
 	secretKey, endpoint, err := createBucketAccess(ctx, userName, policyName, bucketName, secret.Data)
 	if err != nil {
-		eMsg = fmt.Sprintf("error while creating access for bucket %s", bucketName)
+		eMsg = fmt.Sprintf("Bucket access grant failed for bucket '%s'", bucketName)
 		s.log.Error(err, eMsg)
 		return &cosi.DriverGrantBucketAccessResponse{
 			AccountId:   maskedBucketAccessName,
@@ -229,7 +229,7 @@ func (s *Server) DriverGrantBucketAccess(ctx context.Context, req *cosi.DriverGr
 	return &cosi.DriverGrantBucketAccessResponse{
 		AccountId:   maskedBucketAccessName,
 		Credentials: credMap,
-	}, status.Error(codes.OK, "Bucket access grant successfully completed")
+	}, status.Error(codes.OK, fmt.Sprintf("Bucket access granted successfully for '%s' on bucket '%s'", bucketAccessName, bucketName))
 }
 
 // DriverRevokeBucketAccess revokes all access to a bucket for a specific account.
@@ -250,7 +250,7 @@ func (s *Server) DriverRevokeBucketAccess(ctx context.Context, req *cosi.DriverR
 	bucket, err := s.BucketClientset.ObjectstorageV1alpha1().Buckets().Get(ctx, bucketName, metav1.GetOptions{})
 	if err != nil {
 		s.log.Error(err, "failed to get bucket object", "bucketName", bucketName)
-		return nil, utils.ToGRPCStatusError(fmt.Sprintf("failed to get details from bucket: %s", bucketName), err)
+		return nil, utils.ToGRPCStatusError(fmt.Sprintf("Bucket access revoke failed: unable to get bucket '%s'", bucketName), err)
 	}
 
 	// TODO: This is for time being, until side-car & driver is patched to receive parameters along with the access revoke request
@@ -260,25 +260,24 @@ func (s *Server) DriverRevokeBucketAccess(ctx context.Context, req *cosi.DriverR
 	name, namespace, err := getSecretNameAndNamespace(ctx, param)
 
 	if err != nil {
-		eMsg = "error while retrieving details of secret used in bucket access class"
+		eMsg = "Bucket access revoke failed: unable to retrieve secret details from BucketAccessClass"
 		s.log.Error(err, eMsg)
 		return &cosi.DriverRevokeBucketAccessResponse{}, utils.ToGRPCStatusError(eMsg, err)
 	}
 
 	secret, err := getSecret(s.K8sClientset, ctx, name, namespace)
 	if err != nil || secret == nil || secret.Data == nil || len(secret.Data) == 0 {
-		eMsg = fmt.Sprintf("error while fetching secret %s used in bucket access class", name)
-		s.log.Error(err, eMsg)
+		eMsg = fmt.Sprintf("Bucket access revoke failed: unable to fetch secret '%s'", name)
 		return &cosi.DriverRevokeBucketAccessResponse{}, utils.ToGRPCStatusError(eMsg, err)
 	}
 
 	if err = deleteBucketAccess(ctx, userName, policyName, bucketName, secret.Data); err != nil {
-		eMsg = fmt.Sprintf("error while deleting access for bucket %s", bucketName)
+		eMsg = fmt.Sprintf("Bucket access revoke failed for bucket '%s'", bucketName)
 		s.log.Error(err, eMsg)
 		return &cosi.DriverRevokeBucketAccessResponse{}, utils.ToGRPCStatusError(eMsg, err)
 	}
 
-	return &cosi.DriverRevokeBucketAccessResponse{}, status.Error(codes.OK, "Bucket access revoke successfully completed")
+	return &cosi.DriverRevokeBucketAccessResponse{}, status.Error(codes.OK, fmt.Sprintf("Bucket access revoked successfully for '%s' on bucket '%s'", accessName, bucketName))
 
 }
 
@@ -336,7 +335,7 @@ func (c *S3Client) CreateBucket(ctx context.Context, bucketName string, req util
 		if logger.GetSink() != nil {
 			logger.Error(fmt.Errorf("unexpected status code: %d", resp.StatusCode), "Failed to create bucket", "bucketName", bucketName, "status", resp.StatusCode, "response", string(body), "payload", string(payload), "url", url)
 		}
-		return fmt.Errorf("failed to create bucket: %s", string(body))
+		return fmt.Errorf("failed to create bucket: %s", utils.ParseS3ErrorResponse(body))
 	}
 	return nil
 }
@@ -380,7 +379,7 @@ func (c *S3Client) DeleteBucket(ctx context.Context, bucketName string) error {
 		if logger.GetSink() != nil {
 			logger.Error(fmt.Errorf("unexpected status code: %d", resp.StatusCode), "Failed to delete bucket", "bucketName", bucketName, "status", resp.StatusCode, "response", string(body), "url", url)
 		}
-		return fmt.Errorf("failed to delete bucket: %s", string(body))
+		return fmt.Errorf("failed to delete bucket: %s", utils.ParseS3ErrorResponse(body))
 	}
 	return nil
 }

--- a/servers/provisioner/utils/errors.go
+++ b/servers/provisioner/utils/errors.go
@@ -4,25 +4,118 @@
 package utils
 
 import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
 	"strings"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
-// ClassifyError inspects the error message and returns a gRPC status error with
-// the appropriate error code. This centralises error-code mapping so that all
-// Driver* methods (and consequently Kubernetes events) carry a meaningful code.
+// S3ErrorResponse represents the standard S3 XML error response.
+type S3ErrorResponse struct {
+	XMLName   xml.Name `xml:"Error"`
+	Code      string   `xml:"Code"`
+	Message   string   `xml:"Message"`
+	Resource  string   `xml:"Resource"`
+	RequestID string   `xml:"RequestId"`
+}
+
+// ParseS3ErrorResponse attempts to parse a raw S3 XML error body into a
+// concise, human-readable string. If parsing fails it falls back to returning
+// the raw body (truncated to 256 chars) so the error is still actionable.
+func ParseS3ErrorResponse(body []byte) string {
+	var s3Err S3ErrorResponse
+	if err := xml.Unmarshal(body, &s3Err); err == nil && s3Err.Code != "" {
+		if s3Err.Message != "" {
+			return fmt.Sprintf("S3 error %s: %s", s3Err.Code, s3Err.Message)
+		}
+		return fmt.Sprintf("S3 error %s", s3Err.Code)
+	}
+	// Fallback: return truncated raw body
+	raw := strings.TrimSpace(string(body))
+	if len(raw) > 256 {
+		raw = raw[:256] + "..."
+	}
+	return raw
+}
+
+// IAMErrorResponse represents the JSON error response from DSCC/IAM APIs.
+type IAMErrorResponse struct {
+	Error     string `json:"error"`
+	ErrorCode string `json:"errorCode"`
+}
+
+// ParseIAMErrorResponse attempts to parse a raw DSCC/IAM JSON error body into a
+// concise, human-readable string. If parsing fails it falls back to returning
+// the raw body (truncated to 256 chars) so the error is still actionable.
+func ParseIAMErrorResponse(body []byte) string {
+	var iamErr IAMErrorResponse
+	if err := json.Unmarshal(body, &iamErr); err == nil && (iamErr.ErrorCode != "" || iamErr.Error != "") {
+		if iamErr.ErrorCode != "" && iamErr.Error != "" {
+			return fmt.Sprintf("DSCC error %s: %s", iamErr.ErrorCode, iamErr.Error)
+		}
+		if iamErr.ErrorCode != "" {
+			return fmt.Sprintf("DSCC error %s", iamErr.ErrorCode)
+		}
+		return fmt.Sprintf("DSCC error: %s", iamErr.Error)
+	}
+	// Fallback: return truncated raw body
+	raw := strings.TrimSpace(string(body))
+	if len(raw) > 256 {
+		raw = raw[:256] + "..."
+	}
+	return raw
+}
+
+// BodyExtractor is implemented by errors that carry a raw response body
+// (e.g. the SDK's GenericOpenAPIError). This avoids a direct dependency
+// on the SDK package.
+type BodyExtractor interface {
+	Body() []byte
+}
+
+// FormatIAMError enriches a DSCC/IAM API error with the parsed response body.
+// If the error implements BodyExtractor (e.g. GenericOpenAPIError), the body is
+// parsed via ParseIAMErrorResponse for a human-readable message. Otherwise the
+// original error string is returned as-is.
+func FormatIAMError(action string, err error) error {
+	if err == nil {
+		return nil
+	}
+	if be, ok := err.(BodyExtractor); ok {
+		if body := be.Body(); len(body) > 0 {
+			parsed := ParseIAMErrorResponse(body)
+			return fmt.Errorf("%s: %s", action, parsed)
+		}
+	}
+	return fmt.Errorf("%s: %s", action, err.Error())
+}
+
+// ToGRPCStatusError inspects the error message and returns a gRPC status error
+// with the appropriate error code and a concise, actionable description.
 //
-// Mapping rules (evaluated in order):
+// Mapping rules (evaluated in order – S3 error codes first, then general):
 //
-//	"already exists"          → codes.AlreadyExists
-//	"permission denied",
-//	"forbidden", "403"        → codes.PermissionDenied
-//	"invalid", "required",
-//	"unsupported"             → codes.InvalidArgument
-//	"not found", "404"        → codes.NotFound
-//	everything else           → codes.Internal
+//	S3: AccessDenied, AccountProblem,
+//	    InvalidAccessKeyId, SignatureDoesNotMatch  → codes.PermissionDenied
+//	S3: BucketAlreadyExists,
+//	    BucketAlreadyOwnedByYou                    → codes.AlreadyExists
+//	S3: NoSuchBucket, NoSuchKey                    → codes.NotFound
+//	S3: BucketNotEmpty                             → codes.FailedPrecondition
+//	IAM: DOWNSTREAM_SERVICE_ERROR, empty token,
+//	     401 Unauthorized                          → codes.Unauthenticated
+//	General: "already exists"                      → codes.AlreadyExists
+//	General: "permission denied", "forbidden",
+//	         "403", "accessdenied"                 → codes.PermissionDenied
+//	General: "invalid", "required",
+//	         "unsupported"                         → codes.InvalidArgument
+//	General: "not found", "404",
+//	         "nosuchbucket", "nosuchkey"           → codes.NotFound
+//	General: "not empty", "bucketnotempty"         → codes.FailedPrecondition
+//	General: connection / timeout errors           → codes.Unavailable
+//	everything else                                → codes.Internal
 func ToGRPCStatusError(msg string, err error) error {
 	errMsg := ""
 	if err != nil {
@@ -32,28 +125,95 @@ func ToGRPCStatusError(msg string, err error) error {
 
 	var code codes.Code
 	switch {
-	case strings.Contains(combined, "already exists"):
+	// --- S3 & general: already exists ---
+	case strings.Contains(combined, "bucketalreadyexists") ||
+		strings.Contains(combined, "bucketalreadyownedbyyou") ||
+		strings.Contains(combined, "already exists") ||
+		strings.Contains(combined, "already present"):
 		code = codes.AlreadyExists
-	case strings.Contains(combined, "permission denied") ||
+
+	// --- IAM/GLCP: authentication (token / credentials) ---
+	case strings.Contains(combined, "empty access token") ||
+		strings.Contains(combined, "empty token received") ||
+		strings.Contains(combined, "failed to generate token") ||
+		strings.Contains(combined, "401 unauthorized") ||
+		strings.Contains(combined, "token rest api returned status 401") ||
+		strings.Contains(combined, "downstream_service_error") ||
+		strings.Contains(combined, "unauthenticated"):
+		code = codes.Unauthenticated
+
+	// --- S3 & general: permission / auth ---
+	case strings.Contains(combined, "accessdenied") ||
+		strings.Contains(combined, "invalidaccesskeyid") ||
+		strings.Contains(combined, "signaturedoesnotmatch") ||
+		strings.Contains(combined, "accountproblem") ||
+		strings.Contains(combined, "permission denied") ||
 		strings.Contains(combined, "forbidden") ||
-		strings.Contains(combined, "403"):
+		strings.Contains(combined, "403") ||
+		strings.Contains(combined, "token rest api returned status 403"):
 		code = codes.PermissionDenied
+
+	// --- S3 & general: not found ---
+	case strings.Contains(combined, "nosuchbucket") ||
+		strings.Contains(combined, "nosuchkey") ||
+		strings.Contains(combined, "not found") ||
+		strings.Contains(combined, "err_resource_not_found") ||
+		strings.Contains(combined, "404"):
+		code = codes.NotFound
+
+	// --- S3 & general: precondition (e.g. bucket not empty) ---
+	case strings.Contains(combined, "bucketnotempty") ||
+		strings.Contains(combined, "not empty"):
+		code = codes.FailedPrecondition
+
+	// --- connectivity / timeout ---
+	case strings.Contains(combined, "connection refused") ||
+		strings.Contains(combined, "no such host") ||
+		strings.Contains(combined, "timeout") ||
+		strings.Contains(combined, "dial tcp") ||
+		strings.Contains(combined, "503 service unavailable") ||
+		strings.Contains(combined, "token rest api returned status 503") ||
+		strings.Contains(combined, "verify the connectivity"):
+		code = codes.Unavailable
+
+	// --- general: invalid input ---
 	case strings.Contains(combined, "invalid") ||
 		strings.Contains(combined, "required") ||
 		strings.Contains(combined, "unsupported"):
 		code = codes.InvalidArgument
-	case strings.Contains(combined, "not found") ||
-		strings.Contains(combined, "404"):
-		code = codes.NotFound
+
 	default:
 		code = codes.Internal
 	}
 
-	// Use the human-readable msg as the status message; append the
-	// underlying error when available.
+	// Build a concise, actionable message for the Kubernetes event.
 	detail := msg
 	if err != nil {
 		detail = msg + ": " + err.Error()
 	}
+	if hint := actionHint(code); hint != "" {
+		detail = detail + " — " + hint
+	}
 	return status.Error(code, detail)
+}
+
+// actionHint returns a short, user-facing remediation hint for common error
+// codes so that Kubernetes events are immediately actionable.
+func actionHint(code codes.Code) string {
+	switch code {
+	case codes.Unauthenticated:
+		return "verify GLCP API client credentials and token endpoint in the BucketAccessClass secret"
+	case codes.PermissionDenied:
+		return "verify credentials and access policies in Alletra Storage MP X10000"
+	case codes.Unavailable:
+		return "re-check connectivity to Alletra Storage MP X10000"
+	case codes.AlreadyExists:
+		return "resource already exists, no action needed if this is expected"
+	case codes.NotFound:
+		return "resource not found, verify the resource name and backend state"
+	case codes.FailedPrecondition:
+		return "precondition not met (e.g. bucket is not empty), resolve before retrying"
+	default:
+		return ""
+	}
 }


### PR DESCRIPTION
- Parse S3 XML error responses into human-readable messages instead of exposing raw XML in Kubernetes events
- Map S3 error codes (AccessDenied, BucketAlreadyExists, NoSuchBucket, etc.) to appropriate gRPC status codes
- Add actionable remediation hints to error messages (e.g. verify credentials and access policies in DSCC/Homefleet)
- Include gRPC error code label in event messages for quick triage
- Add connectivity/timeout error detection with Unavailable code
- Remove duplicate failed to create/delete bucket prefixes in error chain
- Include resource names in success event messages