### PR TITLE
Add support for GLCP GreenAuth (workspace-based authentication) and improve log security.

### DIFF
--- a/docs/examples/cosi-secret.yaml
+++ b/docs/examples/cosi-secret.yaml
@@ -13,5 +13,6 @@ stringData:
   endpoint: http://192.168.1.100:8080
   glcpUserClientId: GLCP_USER_ID
   glcpUserSecretKey: GLCP_USER_KEY
+  glcpWorkspaceId: GLCP_WORKSPACE_ID
   dsccZone: us1.data.cloud.hpe.com
   clusterSerialNumber: XX0000000000XX

--- a/iam/s3_access_policy.go
+++ b/iam/s3_access_policy.go
@@ -37,7 +37,7 @@ func NewS3Policy(policyName, bucketName, systemId string, client *sdk.APIClient,
 func (p *s3policy) GetS3AccessPolicy() (*sdk.AccessPolicy, error) {
 	ap, r, err := p.client.ObjectstoreIdentitiesAPI.DeviceType7GetAccessPolicyById(p.context, p.systemId, p.name).Execute()
 	if err == nil && r.StatusCode != http.StatusOK {
-		err = fmt.Errorf("request failed while fetching s3 access policy %s, err : %v", p.name, r)
+		err = fmt.Errorf("request failed while fetching s3 access policy %s, err : %v", utils.MaskName(p.name), r)
 	}
 	return ap, err
 }
@@ -78,7 +78,7 @@ func (p *s3policy) CreateS3AccessPolicy() (*sdk.TaskResponseUi, error) {
 	taskUI, r, err := p.client.ObjectstoreIdentitiesAPI.DeviceType7CreateAccessPolicy(p.context, p.systemId).
 		CreateAccessPolicyBody(createAccessPolicyBody).Execute()
 	if err == nil && (r.StatusCode != http.StatusAccepted || taskUI.GetStatus() != string(SUBMITTED)) {
-		err = fmt.Errorf("request failed while creating s3 access policy %s, err: %v", p.name, r)
+		err = fmt.Errorf("request failed while creating s3 access policy %s, err: %v", utils.MaskName(p.name), r)
 	}
 	return taskUI, err
 }
@@ -92,7 +92,7 @@ func (p *s3policy) UpdateS3AccessPolicy() (*sdk.TaskResponseUi, error) {
 	taskUI, r, err := p.client.ObjectstoreIdentitiesAPI.DeviceType7UpdateAccessPolicyById(p.context, p.systemId, p.name).
 		UpdateAccessPolicyBody(updateAccessPolicyBody).Execute()
 	if err == nil && (r.StatusCode != http.StatusAccepted || taskUI.GetStatus() != string(SUBMITTED)) {
-		err = fmt.Errorf("request failed while updating s3 access policy %s, err: %v", p.name, r)
+		err = fmt.Errorf("request failed while updating s3 access policy %s, err: %v", utils.MaskName(p.name), r)
 	}
 	return taskUI, err
 }
@@ -104,7 +104,7 @@ func (p *s3policy) DeleteS3AccessPolicy() (*sdk.TaskResponseUi, error) {
 	taskUI, r, err := p.client.ObjectstoreIdentitiesAPI.DeviceType7DeleteAccessPolicyById(p.context, p.systemId, p.name).Execute()
 
 	if err == nil && (r.StatusCode != http.StatusAccepted || taskUI.GetStatus() != string(SUBMITTED)) {
-		err = fmt.Errorf("request failed while deleting s3 access policy %s, err: %v", p.name, r)
+		err = fmt.Errorf("request failed while deleting s3 access policy %s, err: %v", utils.MaskName(p.name), r)
 	}
 	return taskUI, err
 }

--- a/iam/s3_user.go
+++ b/iam/s3_user.go
@@ -60,8 +60,8 @@ func (u *s3user) UserExists() (bool, error) {
 				" secret, and GLCP_COMMON_CLOUD in COSI pod",
 				"response body", body)
 			return false, err
-		}else{
-		    log.Error(err, "Received error while fetching user details from DSCC.", "statusCode", r.StatusCode, "status", r.Status, "response body", body)	
+		} else {
+			log.Error(err, "Received error while fetching user details from DSCC.", "statusCode", r.StatusCode, "status", r.Status, "response body", body)
 		}
 	}
 	return false, err

--- a/iam/s3_user.go
+++ b/iam/s3_user.go
@@ -77,11 +77,11 @@ func (u *s3user) CreateS3User() (string, error) {
 	if err != nil {
 		if r != nil {
 			_, body := getResponseErrorCode(u.context, r)
-			log.Error(err, "Failed to create S3 user in DSCC", "user", u.name, "statusCode", r.StatusCode, "status", r.Status, "response body", body)
+			log.Error(err, "Failed to create S3 user in DSCC", "user", utils.MaskName(u.name), "statusCode", r.StatusCode, "status", r.Status, "response body", body)
 		}
 		return "", err
 	} else if r.StatusCode != http.StatusCreated {
-		return "", fmt.Errorf("request failed while creating s3 user %s, err: %v", u.name, r)
+		return "", fmt.Errorf("request failed while creating s3 user %s, err: %v", utils.MaskName(u.name), r)
 	}
 	return resp.GetSecretKey(), nil
 }
@@ -95,7 +95,7 @@ func (u *s3user) ResetPassword() (string, error) {
 	if err != nil {
 		return "", err
 	} else if r.StatusCode != http.StatusCreated {
-		return "", fmt.Errorf("request failed while resetting s3 user %s password, err: %v", u.name, r)
+		return "", fmt.Errorf("request failed while resetting s3 user %s password, err: %v", utils.MaskName(u.name), r)
 	}
 	return resp.GetSecretKey(), nil
 }
@@ -108,7 +108,7 @@ func (u *s3user) ApplyPolicy(policies []string) (*sdk.TaskResponseUi, error) {
 
 	taskUI, r, err := u.client.ObjectstoreIdentitiesAPI.ApplyPolicy(u.context, u.systemId).ApplyPolicy(policy).Execute()
 	if err == nil && (r.StatusCode != http.StatusAccepted || taskUI.GetStatus() != string(SUBMITTED)) {
-		err = fmt.Errorf("request failed while applying policies %v, to the user %s, err: %v", policies, u.name, r)
+		err = fmt.Errorf("request failed while applying policies %v, to the user %s, err: %v", policies, utils.MaskName(u.name), r)
 	}
 	return taskUI, err
 }
@@ -119,7 +119,7 @@ func (u *s3user) ApplyPolicy(policies []string) (*sdk.TaskResponseUi, error) {
 func (u *s3user) DeleteS3User() (*sdk.TaskResponseUi, error) {
 	taskUI, r, err := u.client.ObjectstoreIdentitiesAPI.DeviceType7DeleteUserById(u.context, u.systemId, u.name).Execute()
 	if err == nil && (r.StatusCode != http.StatusAccepted || taskUI.GetStatus() != string(SUBMITTED)) {
-		err = fmt.Errorf("request failed while delete s3 user %s, err: %v", u.name, r)
+		err = fmt.Errorf("request failed while delete s3 user %s, err: %v", utils.MaskName(u.name), r)
 	}
 	return taskUI, err
 }

--- a/iam/s3_user.go
+++ b/iam/s3_user.go
@@ -52,6 +52,17 @@ func (u *s3user) UserExists() (bool, error) {
 		return false, err
 	} else if ap != nil && err == nil {
 		return true, nil
+	} else if r != nil {
+		e, body := getResponseErrorCode(u.context, r)
+		if e.GetErrorCode() == string(DOWNSTREAM_SERVICE_ERROR) {
+			log.Error(err, "Downstream service error from DSCC;"+
+				" verify GLCP credentials, workspace in mounted"+
+				" secret, and GLCP_COMMON_CLOUD in COSI pod",
+				"response body", body)
+			return false, err
+		}else{
+		    log.Error(err, "Received error while fetching user details from DSCC.", "statusCode", r.StatusCode, "status", r.Status, "response body", body)	
+		}
 	}
 	return false, err
 }
@@ -59,10 +70,15 @@ func (u *s3user) UserExists() (bool, error) {
 // Creates a user with the passed name in DSCC
 // returns the new secret key of the user
 func (u *s3user) CreateS3User() (string, error) {
+	log := utils.GetLoggerFromContext(u.context)
 	userDetails := *sdk.NewUserDetails(u.name)
 	resp, r, err := u.client.ObjectstoreIdentitiesAPI.DeviceType7CreateUser(u.context, u.systemId).
 		UserDetails(userDetails).Execute()
 	if err != nil {
+		if r != nil {
+			_, body := getResponseErrorCode(u.context, r)
+			log.Error(err, "Failed to create S3 user in DSCC", "user", u.name, "statusCode", r.StatusCode, "status", r.Status, "response body", body)
+		}
 		return "", err
 	} else if r.StatusCode != http.StatusCreated {
 		return "", fmt.Errorf("request failed while creating s3 user %s, err: %v", u.name, r)

--- a/iam/token_service.go
+++ b/iam/token_service.go
@@ -32,17 +32,19 @@ type token_service struct {
 	glcpCloudUrl    string
 	apiCLientId     string
 	apiClientSecret string
+	glcpWorkspaceId string
 	proxy           string
 	onPremCloudCA   string // Base64 encoded CA certificate for on-premise DSCC
 	log             *logr.Logger
 }
 
 // Creates an instance of the TokenService struct
-func NewTokenService(glcpUrl, clientId, secret, proxy, onPremCloudCA string, log *logr.Logger) *token_service {
+func NewTokenService(glcpUrl, clientId, secret, workspaceId, proxy, onPremCloudCA string, log *logr.Logger) *token_service {
 	return &token_service{
 		glcpCloudUrl:    glcpUrl,
 		apiCLientId:     clientId,
 		apiClientSecret: secret,
+		glcpWorkspaceId: workspaceId,
 		proxy:           proxy,
 		onPremCloudCA:   onPremCloudCA,
 		log:             log,
@@ -53,10 +55,20 @@ func (t *token_service) string() (s string) {
 	return fmt.Sprintf("grant_type=%s&client_id=%s&client_secret=%s", ACCESS_GRANT_TYPE, t.apiCLientId, t.apiClientSecret)
 }
 
+func (t *token_service) buildTokenUrl() (uri string) {
+	if len(t.glcpWorkspaceId) > 0 {
+		t.log.Info("GLCP workspace ID provided, authenticating workspace based token request")
+		return fmt.Sprintf("%s/%s/%s/%s", t.glcpCloudUrl, GLCP_ACCESS_ENDPOINT_PREFIX, t.glcpWorkspaceId, GLCP_ACCESS_ENDPOINT_SUFFIX)
+	}
+	// TODO: Need to confirm with GLCP team if the legacy user is supported officially to use new endpoint. 
+	t.log.Info("No GLCP workspace ID provided, going with legacy authentication for token request")
+	return fmt.Sprintf("%s/%s", t.glcpCloudUrl, GLCP_ACCESS_TOKEN_URL)
+}
+
 // Creates a fresh bearer token for the GLCP API user
 func (t *token_service) GetAccessToken() (string, error) {
 	h := map[string]string{"Content-Type": APPLICATION_URL_ENCODED}
-	cloudUrl := fmt.Sprintf("%s/%s", t.glcpCloudUrl, GLCP_ACCESS_TOKEN_URL)
+	cloudUrl := t.buildTokenUrl()
 	if !strings.Contains(cloudUrl, "https") {
 		cloudUrl = "https://" + cloudUrl
 	}

--- a/iam/token_service.go
+++ b/iam/token_service.go
@@ -56,13 +56,7 @@ func (t *token_service) string() (s string) {
 }
 
 func (t *token_service) buildTokenUrl() (uri string) {
-	if len(t.glcpWorkspaceId) > 0 {
-		t.log.Info("GLCP workspace ID provided, authenticating workspace based token request")
-		return fmt.Sprintf("%s/%s/%s/%s", t.glcpCloudUrl, GLCP_ACCESS_ENDPOINT_PREFIX, t.glcpWorkspaceId, GLCP_ACCESS_ENDPOINT_SUFFIX)
-	}
-	// TODO: Need to confirm with GLCP team if the legacy user is supported officially to use new endpoint. 
-	t.log.Info("No GLCP workspace ID provided, going with legacy authentication for token request")
-	return fmt.Sprintf("%s/%s", t.glcpCloudUrl, GLCP_ACCESS_TOKEN_URL)
+	return fmt.Sprintf("%s/%s/%s/%s", t.glcpCloudUrl, GLCP_ACCESS_ENDPOINT_PREFIX, t.glcpWorkspaceId, GLCP_ACCESS_ENDPOINT_SUFFIX)
 }
 
 // Creates a fresh bearer token for the GLCP API user

--- a/iam/token_service_test.go
+++ b/iam/token_service_test.go
@@ -23,10 +23,11 @@ func Test_GetAccessToken(t *testing.T) {
 	glcpUrl := "sso.cloud.example.com"
 	glcpUser := "xxxxxxx-zzz-123-3456"
 	glcpUserSecret := "zzzzzrandomxxxxxxzzzzz"
+	glcpWorkspaceId := "workspace-1234"
 	proxy := "http://dummy_proxy:8080"
 	log := stdr.New(stdlog.New(os.Stdout, "", stdlog.LstdFlags))
 
-	ts := NewTokenService(glcpUrl, glcpUser, glcpUserSecret, proxy, "", &log)
+	ts := NewTokenService(glcpUrl, glcpUser, glcpUserSecret, glcpWorkspaceId, proxy, "", &log)
 
 	t.Run("GetAccessToken successful", func(t *testing.T) {
 		expToken := testExpToken
@@ -102,13 +103,14 @@ func Test_GetAccessToken_WithCA(t *testing.T) {
 	glcpUrl := "sso.on-prem.example.com"
 	glcpUser := "xxxxxxx-zzz-123-3456"
 	glcpUserSecret := "zzzzzrandomxxxxxxzzzzz"
+	glcpWorkspaceId := "workspace-1234"
 	log := stdr.New(stdlog.New(os.Stdout, "", stdlog.LstdFlags))
 
 	// Generate CA certificate at runtime to avoid hardcoded certificate patterns in source code
 	validCACert := generateTestCACert(t)
 
 	t.Run("GetAccessToken with CA certificate successful", func(t *testing.T) {
-		ts := NewTokenService(glcpUrl, glcpUser, glcpUserSecret, "", validCACert, &log)
+		ts := NewTokenService(glcpUrl, glcpUser, glcpUserSecret, glcpWorkspaceId, "", validCACert, &log)
 		expToken := testExpToken
 		oauth2 := oauth2_token{
 			AccessToken: expToken,
@@ -131,7 +133,7 @@ func Test_GetAccessToken_WithCA(t *testing.T) {
 	})
 
 	t.Run("GetAccessToken with CA certificate and proxy", func(t *testing.T) {
-		ts := NewTokenService(glcpUrl, glcpUser, glcpUserSecret, "http://dummy_proxy:8080", validCACert, &log)
+		ts := NewTokenService(glcpUrl, glcpUser, glcpUserSecret, glcpWorkspaceId, "http://dummy_proxy:8080", validCACert, &log)
 		expToken := testExpToken
 		oauth2 := oauth2_token{
 			AccessToken: expToken,
@@ -154,7 +156,7 @@ func Test_GetAccessToken_WithCA(t *testing.T) {
 	})
 
 	t.Run("GetAccessToken with invalid base64 CA certificate", func(t *testing.T) {
-		ts := NewTokenService(glcpUrl, glcpUser, glcpUserSecret, "", "not-valid-base64!!!", &log)
+		ts := NewTokenService(glcpUrl, glcpUser, glcpUserSecret, glcpWorkspaceId, "", "not-valid-base64!!!", &log)
 		// PostRequest will fail because buildHTTPTransport will fail with invalid base64
 		token, err := ts.GetAccessToken()
 		if err == nil {
@@ -165,11 +167,29 @@ func Test_GetAccessToken_WithCA(t *testing.T) {
 
 	t.Run("GetAccessToken with invalid PEM CA certificate", func(t *testing.T) {
 		// Valid base64 but not a valid PEM certificate
-		ts := NewTokenService(glcpUrl, glcpUser, glcpUserSecret, "", "dGhpcyBpcyBub3QgYSB2YWxpZCBjZXJ0aWZpY2F0ZQ==", &log)
+		ts := NewTokenService(glcpUrl, glcpUser, glcpUserSecret, glcpWorkspaceId, "", "dGhpcyBpcyBub3QgYSB2YWxpZCBjZXJ0aWZpY2F0ZQ==", &log)
 		token, err := ts.GetAccessToken()
 		if err == nil {
 			t.Errorf("FAILED: expected error for invalid PEM CA certificate")
 		}
 		assert.Equal(t, len(token), 0)
+	})
+}
+
+func Test_buildTokenUrl(t *testing.T) {
+	log := stdr.New(stdlog.New(os.Stdout, "", stdlog.LstdFlags))
+    autUri := "https://sso.cloud.example.com"
+	t.Run("buildTokenUrl with workspace ID", func(t *testing.T) {
+		ts := NewTokenService(autUri, "client-id", "client-secret", "workspace-1234", "", "", &log)
+		uri := ts.buildTokenUrl()
+		expected := autUri + "/authorization/v2/oauth2/workspace-1234/token"
+		assert.Equal(t, uri, expected)
+	})
+
+	t.Run("buildTokenUrl without workspace ID (legacy)", func(t *testing.T) {
+		ts := NewTokenService(autUri, "client-id", "client-secret", "", "", "", &log)
+		uri := ts.buildTokenUrl()
+		expected := autUri + "/as/token.oauth2"
+		assert.Equal(t, uri, expected)
 	})
 }

--- a/iam/token_service_test.go
+++ b/iam/token_service_test.go
@@ -178,18 +178,11 @@ func Test_GetAccessToken_WithCA(t *testing.T) {
 
 func Test_buildTokenUrl(t *testing.T) {
 	log := stdr.New(stdlog.New(os.Stdout, "", stdlog.LstdFlags))
-    autUri := "https://sso.cloud.example.com"
+	autUri := "https://sso.cloud.example.com"
 	t.Run("buildTokenUrl with workspace ID", func(t *testing.T) {
 		ts := NewTokenService(autUri, "client-id", "client-secret", "workspace-1234", "", "", &log)
 		uri := ts.buildTokenUrl()
 		expected := autUri + "/authorization/v2/oauth2/workspace-1234/token"
-		assert.Equal(t, uri, expected)
-	})
-
-	t.Run("buildTokenUrl without workspace ID (legacy)", func(t *testing.T) {
-		ts := NewTokenService(autUri, "client-id", "client-secret", "", "", "", &log)
-		uri := ts.buildTokenUrl()
-		expected := autUri + "/as/token.oauth2"
 		assert.Equal(t, uri, expected)
 	})
 }

--- a/iam/types.go
+++ b/iam/types.go
@@ -8,7 +8,6 @@ import (
 
 var (
 	ACCESS_GRANT_TYPE           = "client_credentials"
-	GLCP_ACCESS_TOKEN_URL       = "as/token.oauth2"
 	GLCP_ACCESS_ENDPOINT_PREFIX = "authorization/v2/oauth2"
 	GLCP_ACCESS_ENDPOINT_SUFFIX = "token"
 	HTTP_REQUEST_TIMEOUT        = 30 * time.Second
@@ -66,6 +65,6 @@ const (
 type HttpErrorCode string
 
 const (
-	ERR_RESOURCE_NOT_FOUND HttpErrorCode = "ERR_RESOURCE_NOT_FOUND"
+	ERR_RESOURCE_NOT_FOUND   HttpErrorCode = "ERR_RESOURCE_NOT_FOUND"
 	DOWNSTREAM_SERVICE_ERROR HttpErrorCode = "DOWNSTREAM_SERVICE_ERROR"
 )

--- a/iam/types.go
+++ b/iam/types.go
@@ -7,12 +7,14 @@ import (
 )
 
 var (
-	ACCESS_GRANT_TYPE       = "client_credentials"
-	GLCP_ACCESS_TOKEN_URL   = "as/token.oauth2"
-	HTTP_REQUEST_TIMEOUT    = 30 * time.Second
-	APPLICATION_URL_ENCODED = "application/x-www-form-urlencoded"
-	DSCC_POLICY_VERSION     = "2012-10-17"
-	WAIT_TIME               = 2 * time.Second
+	ACCESS_GRANT_TYPE           = "client_credentials"
+	GLCP_ACCESS_TOKEN_URL       = "as/token.oauth2"
+	GLCP_ACCESS_ENDPOINT_PREFIX = "authorization/v2/oauth2"
+	GLCP_ACCESS_ENDPOINT_SUFFIX = "token"
+	HTTP_REQUEST_TIMEOUT        = 30 * time.Second
+	APPLICATION_URL_ENCODED     = "application/x-www-form-urlencoded"
+	DSCC_POLICY_VERSION         = "2012-10-17"
+	WAIT_TIME                   = 2 * time.Second
 )
 
 // Defines types of entities in DSCC , ex: USER|POLICY
@@ -65,4 +67,5 @@ type HttpErrorCode string
 
 const (
 	ERR_RESOURCE_NOT_FOUND HttpErrorCode = "ERR_RESOURCE_NOT_FOUND"
+	DOWNSTREAM_SERVICE_ERROR HttpErrorCode = "DOWNSTREAM_SERVICE_ERROR"
 )

--- a/scripts/cosi_secret/hpe_create_cosi_secret.sh
+++ b/scripts/cosi_secret/hpe_create_cosi_secret.sh
@@ -11,15 +11,15 @@ help()
     echo -e "\nSyntax:"
     echo -e "     hpe_create_cosi_secret.sh [-h|--help] [-s|--s3_credentials S3_ACCESS_KEY,S3_SECRET_KEY] [-e|--s3_endpoint ENDPOINT] [-g|--glcp_credentials GLCP_USER_CLIENTID,GLCP_USER_SECRET_KEY] [-d|--dscc_zone DSCC_ZONE] [-c|--cluster_serial_number CLUSTER_SERIAL_NUMBER] [--glcp_ca GLCP_CA_CERTIFICATE] [--cosi_secret_name COSI_SECRET_NAME] [--cosi_secret_namespace COSI_SECRET_NAMESPACE]\n"
     echo -e "Options:"
-    echo -e "-h|--help                                                          Print this Help."
-    echo -e "-s|--s3_credentials S3_ACCESS_KEY,S3_SECRET_KEY                    Specify the S3 admin user's access key and secret key separated by commas. (REQUIRED) E.g. -s \"testuser,testuser\""
-    echo -e "-e|--s3_endpoint ENDPOINT                                          Specify the S3 endpoint of the HPE Alletra Storage MP X10000 object storage array, which is derived from its S3 DNS Subdomain name. (REQUIRED) E.g. -e \"http://demo-s3-cluster.storage.com\""
-    echo -e "-g|--glcp_credentials GLCP_USER_CLIENTID,GLCP_USER_SECRET_KEY      Specify the GLCP user's client ID and secret key separated using commas. (REQUIRED) E.g. -g \"xxxxxxx-zzz-123-3456,zzzzzrandomxxxxxxzzzzz\""
-    echo -e "-d|--dscc_zone DSCC_ZONE                                           Specify the DSCC zone. (REQUIRED) E.g. -d \"us1.data.cloud.hpe.com\""
-    echo -e "-c|--cluster_serial_number CLUSTER_SERIAL_NUMBER                   Specify the serial number of the cluster. (REQUIRED) E.g. -c \"XX0000000000XX\""
-    echo -e "--glcp_ca GLCP_CA_CERTIFICATE                                      Specify the base64 encoded CA certificate for on-premise DSCC. (OPTIONAL) E.g. --glcp_ca \"LS0tLS1CRUdJTi...\""
-    echo -e "--cosi_secret_name COSI_SECRET_NAME                                Specify the desired name of the secret. Default: 'cosi-user-secret-\$CLUSTER_SERIAL_NUMBER'. (OPTIONAL) E.g. --cosi_secret_name \"cosi-user-secret-hfdt1y87bc\""
-    echo -e "--cosi_secret_namespace COSI_SECRET_NAMESPACE                      Specify the desired namespace of the secret. Default: 'default'. (OPTIONAL) E.g. --cosi_secret_namespace \"cosi-user\""
+    echo -e "-h|--help                                                                          Print this Help."
+    echo -e "-s|--s3_credentials S3_ACCESS_KEY,S3_SECRET_KEY                                    Specify the S3 admin user's access key and secret key separated by commas. (REQUIRED) E.g. -s \"testuser,testuser\""
+    echo -e "-e|--s3_endpoint ENDPOINT                                                          Specify the S3 endpoint of the HPE Alletra Storage MP X10000 object storage array, which is derived from its S3 DNS Subdomain name. (REQUIRED) E.g. -e \"http://demo-s3-cluster.storage.com\""
+    echo -e "-g|--glcp_credentials GLCP_USER_CLIENTID,GLCP_USER_SECRET_KEY,GLCP_WORKSPACE_ID    Specify the GLCP user's client ID, secret key, and workspace ID separated using commas. (REQUIRED) E.g. -g \"xxxxxxx-zzz-123-3456,zzzzzrandomxxxxxxzzzzz,393xxxxxxxrandomxxxxdummyxx0c773\""
+    echo -e "-d|--dscc_zone DSCC_ZONE                                                           Specify the DSCC zone. (REQUIRED) E.g. -d \"us1.data.cloud.hpe.com\""
+    echo -e "-c|--cluster_serial_number CLUSTER_SERIAL_NUMBER                                   Specify the serial number of the cluster. (REQUIRED) E.g. -c \"XX0000000000XX\""
+    echo -e "--glcp_ca GLCP_CA_CERTIFICATE                                                      Specify the base64 encoded CA certificate for on-premise DSCC. (OPTIONAL) E.g. --glcp_ca \"LS0tLS1CRUdJTi...\""
+    echo -e "--cosi_secret_name COSI_SECRET_NAME                                                Specify the desired name of the secret. Default: 'cosi-user-secret-\$CLUSTER_SERIAL_NUMBER'. (OPTIONAL) E.g. --cosi_secret_name \"cosi-user-secret-hfdt1y87bc\""
+    echo -e "--cosi_secret_namespace COSI_SECRET_NAMESPACE                                      Specify the desired namespace of the secret. Default: 'default'. (OPTIONAL) E.g. --cosi_secret_namespace \"cosi-user\""
     exit 0
 }
 
@@ -51,6 +51,7 @@ create_secret()
         --from-literal=endpoint=${s3_endpoint} \
         --from-literal=glcpUserClientId=${glcp_creds[0]} \
         --from-literal=glcpUserSecretKey=${glcp_creds[1]} \
+        --from-literal=glcpWorkspaceId=${glcp_creds[2]} \
         --from-literal=dsccZone=$dscc_zone \
         --from-literal=clusterSerialNumber=$cluster_serial_number"
     
@@ -158,7 +159,7 @@ option="$1"
 done
 
 # If all mandatory options are not present, return error.
-if [[ "${#s3_creds[@]}" -ne 2 || ! "$s3_endpoint" || "${#glcp_creds[@]}" -ne 2 || ! "$dscc_zone" || ! "$cluster_serial_number" ]]
+if [[ "${#s3_creds[@]}" -ne 2 || ! "$s3_endpoint" || "${#glcp_creds[@]}" -ne 3 || ! "$dscc_zone" || ! "$cluster_serial_number" ]]
 then
     echo "Options -s, -e, -g, -d and -c are required. Please refer Help for more details."
     help

--- a/servers/provisioner/provisioner.go
+++ b/servers/provisioner/provisioner.go
@@ -798,7 +798,7 @@ func createBucketAccess(ctx context.Context, userName, policyName, bucketName st
 	// Create S3 User
 	u := iam.NewS3User(userName, credentials.SystemId, client, ctx)
 
-	log.Info(fmt.Sprintf("Checking if s3 user %s, exists in DSCC", userName))
+	log.Info(fmt.Sprintf("Checking if s3 user %s, exists in DSCC", utils.MaskName(userName)))
 	exist, err := u.UserExists()
 	if err != nil {
 		log.Error(err, "error fetching user details from DSCC. Please verify the connectivity with DSCC, ", credentials.DSCCZone)
@@ -807,10 +807,10 @@ func createBucketAccess(ctx context.Context, userName, policyName, bucketName st
 
 	var secretKey string
 	if !exist {
-		log.Info(fmt.Sprintf("Creating s3 user %s, in DSCC", userName))
+		log.Info(fmt.Sprintf("Creating s3 user %s, in DSCC", utils.MaskName(userName)))
 		secretKey, err = u.CreateS3User()
 	} else {
-		log.Info(fmt.Sprintf("S3 user %s, is seen to be existing in DSCC, resetting password & reusing it for bucket access", userName))
+		log.Info(fmt.Sprintf("S3 user %s, is seen to be existing in DSCC, resetting password & reusing it for bucket access", utils.MaskName(userName)))
 		secretKey, err = u.ResetPassword()
 	}
 	if err != nil || len(secretKey) == 0 {
@@ -820,7 +820,7 @@ func createBucketAccess(ctx context.Context, userName, policyName, bucketName st
 	// Create S3 Access policy
 	p := iam.NewS3Policy(policyName, bucketName, credentials.SystemId, client, ctx)
 
-	log.Info(fmt.Sprintf("Checking if access policy %s, exists in DSCC", policyName))
+	log.Info(fmt.Sprintf("Checking if access policy %s, exists in DSCC", utils.MaskName(policyName)))
 	exist, err = p.PolicyExists()
 	if err != nil {
 		log.Error(err, "error fetching access policy details from DSCC. Please verify the connectivity with DSCC, ", credentials.DSCCZone)
@@ -828,7 +828,7 @@ func createBucketAccess(ctx context.Context, userName, policyName, bucketName st
 	}
 
 	if !exist {
-		log.Info(fmt.Sprintf("Creating access policy %s, in DSCC", policyName))
+		log.Info(fmt.Sprintf("Creating access policy %s, in DSCC", utils.MaskName(policyName)))
 		task, err := p.CreateS3AccessPolicy()
 		if task == nil && err != nil {
 			log.Error(err, "error while creating s3 access policy in DSCC.")
@@ -844,11 +844,11 @@ func createBucketAccess(ctx context.Context, userName, policyName, bucketName st
 
 		}
 	} else {
-		log.Info(fmt.Sprintf("Access policy %s, is seen to be existing in DSCC, reusing it for bucket access", policyName))
+		log.Info(fmt.Sprintf("Access policy %s, is seen to be existing in DSCC, reusing it for bucket access", utils.MaskName(policyName)))
 	}
 
 	// Applying access policy to S3 user
-	log.Info(fmt.Sprintf("Applying access policy %s to s3 user %s", policyName, userName))
+	log.Info(fmt.Sprintf("Applying access policy %s to s3 user %s", utils.MaskName(policyName), utils.MaskName(userName)))
 	task, err := u.ApplyPolicy([]string{policyName})
 	if task == nil && err != nil {
 		log.Error(err, "error while applying policy to user.")
@@ -902,7 +902,7 @@ func deleteBucketAccess(ctx context.Context, userName, policyName, bucketName st
 
 	u := iam.NewS3User(userName, credentials.SystemId, client, ctx)
 
-	log.Info(fmt.Sprintf("Checking if s3 user %s, exists in DSCC", userName))
+	log.Info(fmt.Sprintf("Checking if s3 user %s, exists in DSCC", utils.MaskName(userName)))
 	exist, err := u.UserExists()
 	if err != nil {
 		log.Error(err, fmt.Sprintf("error fetching user details from DSCC %s. Please verify the connectivity with DSCC.", credentials.DSCCZone))
@@ -910,7 +910,7 @@ func deleteBucketAccess(ctx context.Context, userName, policyName, bucketName st
 	}
 
 	if exist {
-		log.Info(fmt.Sprintf("Deleting S3 user %s", userName))
+		log.Info(fmt.Sprintf("Deleting S3 user %s", utils.MaskName(userName)))
 		task, err := u.DeleteS3User()
 		if task == nil && err != nil {
 			log.Error(err, "error while deleting s3 user.")
@@ -927,12 +927,12 @@ func deleteBucketAccess(ctx context.Context, userName, policyName, bucketName st
 		}
 
 	} else {
-		log.Info(fmt.Sprintf("S3 user %s, doesn't exist in DSCC", userName))
+		log.Info(fmt.Sprintf("S3 user %s, doesn't exist in DSCC", utils.MaskName(userName)))
 	}
 
 	p := iam.NewS3Policy(policyName, bucketName, credentials.SystemId, client, ctx)
 
-	log.Info(fmt.Sprintf("Checking if s3 access policy %s, exists in DSCC", policyName))
+	log.Info(fmt.Sprintf("Checking if s3 access policy %s, exists in DSCC", utils.MaskName(policyName)))
 	exist, err = p.PolicyExists()
 	if err != nil {
 		log.Error(err, fmt.Sprintf("error fetching policy details from DSCC %s. Please verify the connectivity with DSCC.", credentials.DSCCZone))
@@ -940,7 +940,7 @@ func deleteBucketAccess(ctx context.Context, userName, policyName, bucketName st
 	}
 
 	if exist {
-		log.Info(fmt.Sprintf("Deleting S3 access policy %s", userName))
+		log.Info(fmt.Sprintf("Deleting S3 access policy %s", utils.MaskName(policyName)))
 		task, err := p.DeleteS3AccessPolicy()
 		if task == nil && err != nil {
 			log.Error(err, "error while deleting s3 access policy.")
@@ -964,8 +964,8 @@ func deleteBucketAccess(ctx context.Context, userName, policyName, bucketName st
 
 // Fetches a fresh bearer token to access DSCC, through GLCP
 func getAccessToken(credentials *utils.IAMCredentials, log *logr.Logger) (string, error) {
-	ts := iam.NewTokenService(credentials.GLCPCommonCloud, credentials.GLCPUser, credentials.GLCPUserSecretKey, credentials.GLCPWorkspaceId, 
-		  credentials.Proxy, credentials.OnPremCloudCA, log)
+	ts := iam.NewTokenService(credentials.GLCPCommonCloud, credentials.GLCPUser, credentials.GLCPUserSecretKey, credentials.GLCPWorkspaceId,
+		credentials.Proxy, credentials.OnPremCloudCA, log)
 	token, err := ts.GetAccessToken()
 	return token, err
 }

--- a/servers/provisioner/provisioner.go
+++ b/servers/provisioner/provisioner.go
@@ -956,7 +956,7 @@ func deleteBucketAccess(ctx context.Context, userName, policyName, bucketName st
 
 		}
 	} else {
-		log.Info(fmt.Sprintf("S3 access policy %s, doesn't exist in DSCC", userName))
+		log.Info(fmt.Sprintf("S3 access policy %s, doesn't exist in DSCC", utils.MaskName(policyName)))
 	}
 	return nil
 

--- a/servers/provisioner/provisioner.go
+++ b/servers/provisioner/provisioner.go
@@ -706,7 +706,8 @@ func getSecret(client *kubernetes.Clientset, ctx context.Context, name, namespac
 
 // Retrieves the GLCP credentials(required to communicate with DSCC) from the passed secret data
 // returns error, if any of the necessary credentials are missing in the passed secret data
-func getGLCPCDetails(data map[string][]byte) (*utils.IAMCredentials, error) {
+func getGLCPCDetails(ctx context.Context, data map[string][]byte) (*utils.IAMCredentials, error) {
+	log := utils.GetLoggerFromContext(ctx)
 	getData := func(key string) (str string, err error) {
 		if val, ok := data[key]; ok {
 			str = string(val)[:]
@@ -720,7 +721,7 @@ func getGLCPCDetails(data map[string][]byte) (*utils.IAMCredentials, error) {
 	glcpCommonCloud := os.Getenv(utils.GLCP_COMMON_CLOUD)
 
 	if len(glcpCommonCloud) == 0 {
-		return nil, fmt.Errorf("unable to fetch GLCP cloud URL form environment")
+		return nil, fmt.Errorf("unable to fetch GLCP cloud URL from environment")
 	}
 	glcpUserClientId, err := getData(utils.GLCP_USER_CLIENTID)
 	if err != nil {
@@ -729,6 +730,11 @@ func getGLCPCDetails(data map[string][]byte) (*utils.IAMCredentials, error) {
 	glcpUserSecretKey, err := getData(utils.GLCP_USER_SECRET_KEY)
 	if err != nil {
 		return nil, err
+	}
+	glcpWorkspaceId, err := getData(utils.GLCP_WORKSPACE_ID)
+	if err != nil {
+		//TODO: Need to confirm with GLCP team & entirly move to new Auth by making this field mandatory.
+		log.Info("unable to fetch GLCP workspace ID from the mounted secret")
 	}
 	dsccZone, err := getData(utils.DSCC_ZONE)
 	if err != nil {
@@ -749,6 +755,7 @@ func getGLCPCDetails(data map[string][]byte) (*utils.IAMCredentials, error) {
 	return &utils.IAMCredentials{
 		GLCPUser:          glcpUserClientId,
 		GLCPUserSecretKey: glcpUserSecretKey,
+		GLCPWorkspaceId:   glcpWorkspaceId,
 		GLCPCommonCloud:   glcpCommonCloud,
 		DSCCZone:          dsccZone,
 		SystemId:          clusterSerialNumber,
@@ -762,7 +769,7 @@ func getGLCPCDetails(data map[string][]byte) (*utils.IAMCredentials, error) {
 // returns an error when S3 user,policy creation fails in DSCC
 func createBucketAccess(ctx context.Context, userName, policyName, bucketName string, data map[string][]byte) (string, string, error) {
 	log := utils.GetLoggerFromContext(ctx)
-	credentials, err := getGLCPCDetails(data)
+	credentials, err := getGLCPCDetails(ctx, data)
 	if err != nil {
 		return "", "", err
 	}
@@ -864,7 +871,7 @@ func createBucketAccess(ctx context.Context, userName, policyName, bucketName st
 func deleteBucketAccess(ctx context.Context, userName, policyName, bucketName string, data map[string][]byte) error {
 	log := utils.GetLoggerFromContext(ctx)
 
-	credentials, err := getGLCPCDetails(data)
+	credentials, err := getGLCPCDetails(ctx, data)
 	if err != nil {
 		return err
 	}
@@ -957,7 +964,8 @@ func deleteBucketAccess(ctx context.Context, userName, policyName, bucketName st
 
 // Fetches a fresh bearer token to access DSCC, through GLCP
 func getAccessToken(credentials *utils.IAMCredentials, log *logr.Logger) (string, error) {
-	ts := iam.NewTokenService(credentials.GLCPCommonCloud, credentials.GLCPUser, credentials.GLCPUserSecretKey, credentials.Proxy, credentials.OnPremCloudCA, log)
+	ts := iam.NewTokenService(credentials.GLCPCommonCloud, credentials.GLCPUser, credentials.GLCPUserSecretKey, credentials.GLCPWorkspaceId, 
+		  credentials.Proxy, credentials.OnPremCloudCA, log)
 	token, err := ts.GetAccessToken()
 	return token, err
 }

--- a/servers/provisioner/provisioner.go
+++ b/servers/provisioner/provisioner.go
@@ -165,12 +165,13 @@ func (s *Server) DriverGrantBucketAccess(ctx context.Context, req *cosi.DriverGr
 
 	// Get the bucket access name from the request
 	bucketAccessName := req.Name
+	maskedBucketAccessName := utils.MaskName(bucketAccessName)
 
 	if req.AuthenticationType != cosi.AuthenticationType_Key {
 		err := fmt.Errorf("%s authenticationType alone is supported by COSI driver", cosi.AuthenticationType_Key)
 		s.log.Error(err, "Unsupported authenticationType")
 		return &cosi.DriverGrantBucketAccessResponse{
-			AccountId:   bucketAccessName,
+			AccountId:   maskedBucketAccessName,
 			Credentials: nil,
 		}, utils.ToGRPCStatusError("Unsupported authenticationType", err)
 	}
@@ -186,7 +187,7 @@ func (s *Server) DriverGrantBucketAccess(ctx context.Context, req *cosi.DriverGr
 		eMsg = "error while retrieving details of secret used in bucket access class"
 		s.log.Error(err, eMsg)
 		return &cosi.DriverGrantBucketAccessResponse{
-			AccountId:   bucketAccessName,
+			AccountId:   maskedBucketAccessName,
 			Credentials: nil,
 		}, utils.ToGRPCStatusError(eMsg, err)
 	}
@@ -196,7 +197,7 @@ func (s *Server) DriverGrantBucketAccess(ctx context.Context, req *cosi.DriverGr
 		eMsg = fmt.Sprintf("error while fetching secret %s used in bucket access class", name)
 		s.log.Error(err, eMsg)
 		return &cosi.DriverGrantBucketAccessResponse{
-			AccountId:   bucketAccessName,
+			AccountId:   maskedBucketAccessName,
 			Credentials: nil,
 		}, utils.ToGRPCStatusError(eMsg, err)
 	}
@@ -206,7 +207,7 @@ func (s *Server) DriverGrantBucketAccess(ctx context.Context, req *cosi.DriverGr
 		eMsg = fmt.Sprintf("error while creating access for bucket %s", bucketName)
 		s.log.Error(err, eMsg)
 		return &cosi.DriverGrantBucketAccessResponse{
-			AccountId:   bucketAccessName,
+			AccountId:   maskedBucketAccessName,
 			Credentials: nil,
 		}, utils.ToGRPCStatusError(eMsg, err)
 	}
@@ -226,7 +227,7 @@ func (s *Server) DriverGrantBucketAccess(ctx context.Context, req *cosi.DriverGr
 	credMap["s3"] = cred
 
 	return &cosi.DriverGrantBucketAccessResponse{
-		AccountId:   bucketAccessName,
+		AccountId:   maskedBucketAccessName,
 		Credentials: credMap,
 	}, status.Error(codes.OK, "Bucket access grant successfully completed")
 }
@@ -243,7 +244,8 @@ func (s *Server) DriverRevokeBucketAccess(ctx context.Context, req *cosi.DriverR
 	policyName := utils.ACCESS_POLICY_PREFIX + accessName
 	var eMsg string
 
-	s.log.Info(fmt.Sprintf("BucketName %s, AccountId %s", bucketName, accessName))
+	maskedAccessName := utils.MaskName(accessName)
+	s.log.Info(fmt.Sprintf("BucketName %s, AccountId %s", bucketName, maskedAccessName))
 	// Get the bucket object
 	bucket, err := s.BucketClientset.ObjectstorageV1alpha1().Buckets().Get(ctx, bucketName, metav1.GetOptions{})
 	if err != nil {
@@ -266,6 +268,7 @@ func (s *Server) DriverRevokeBucketAccess(ctx context.Context, req *cosi.DriverR
 	secret, err := getSecret(s.K8sClientset, ctx, name, namespace)
 	if err != nil || secret == nil || secret.Data == nil || len(secret.Data) == 0 {
 		eMsg = fmt.Sprintf("error while fetching secret %s used in bucket access class", name)
+		s.log.Error(err, eMsg)
 		return &cosi.DriverRevokeBucketAccessResponse{}, utils.ToGRPCStatusError(eMsg, err)
 	}
 
@@ -706,8 +709,7 @@ func getSecret(client *kubernetes.Clientset, ctx context.Context, name, namespac
 
 // Retrieves the GLCP credentials(required to communicate with DSCC) from the passed secret data
 // returns error, if any of the necessary credentials are missing in the passed secret data
-func getGLCPCDetails(ctx context.Context, data map[string][]byte) (*utils.IAMCredentials, error) {
-	log := utils.GetLoggerFromContext(ctx)
+func getGLCPCDetails(data map[string][]byte) (*utils.IAMCredentials, error) {
 	getData := func(key string) (str string, err error) {
 		if val, ok := data[key]; ok {
 			str = string(val)[:]
@@ -733,8 +735,7 @@ func getGLCPCDetails(ctx context.Context, data map[string][]byte) (*utils.IAMCre
 	}
 	glcpWorkspaceId, err := getData(utils.GLCP_WORKSPACE_ID)
 	if err != nil {
-		//TODO: Need to confirm with GLCP team & entirly move to new Auth by making this field mandatory.
-		log.Info("unable to fetch GLCP workspace ID from the mounted secret")
+		return nil, err
 	}
 	dsccZone, err := getData(utils.DSCC_ZONE)
 	if err != nil {
@@ -769,7 +770,7 @@ func getGLCPCDetails(ctx context.Context, data map[string][]byte) (*utils.IAMCre
 // returns an error when S3 user,policy creation fails in DSCC
 func createBucketAccess(ctx context.Context, userName, policyName, bucketName string, data map[string][]byte) (string, string, error) {
 	log := utils.GetLoggerFromContext(ctx)
-	credentials, err := getGLCPCDetails(ctx, data)
+	credentials, err := getGLCPCDetails(data)
 	if err != nil {
 		return "", "", err
 	}
@@ -871,7 +872,7 @@ func createBucketAccess(ctx context.Context, userName, policyName, bucketName st
 func deleteBucketAccess(ctx context.Context, userName, policyName, bucketName string, data map[string][]byte) error {
 	log := utils.GetLoggerFromContext(ctx)
 
-	credentials, err := getGLCPCDetails(ctx, data)
+	credentials, err := getGLCPCDetails(data)
 	if err != nil {
 		return err
 	}

--- a/servers/provisioner/provisioner_test.go
+++ b/servers/provisioner/provisioner_test.go
@@ -491,6 +491,7 @@ func TestDriverGrantBucketAccess(t *testing.T) {
 	patches.ApplyMethodReturn(coreV1, "Secrets", secretInt)
 	log := stdr.New(stdlog.New(os.Stdout, "", stdlog.LstdFlags))
 	accessName := "bucket1_user"
+	maskedAccessName := utils.MaskName(accessName)
 	bucketName := "bucket1"
 	policy := iam.NewS3Policy(utils.ACCESS_POLICY_PREFIX+accessName, bucketName, systemId, nil, context.Background())
 	user := iam.NewS3User(utils.USER_PREFIX+accessName, systemId, nil, context.Background())
@@ -498,6 +499,7 @@ func TestDriverGrantBucketAccess(t *testing.T) {
 	removeSecretData := func(remField string) *v1.Secret {
 		data := map[string][]byte{utils.GLCP_USER_CLIENTID: []byte(glcpCreds.GLCPUser),
 			utils.GLCP_USER_SECRET_KEY: []byte(glcpCreds.GLCPUserSecretKey),
+			utils.GLCP_WORKSPACE_ID:    []byte(glcpCreds.GLCPWorkspaceId),
 			utils.DSCC_ZONE:            []byte(glcpCreds.DSCCZone),
 			utils.ALLETRA_MP_X10K_SNO:  []byte(glcpCreds.SystemId),
 		}
@@ -532,7 +534,7 @@ func TestDriverGrantBucketAccess(t *testing.T) {
 				},
 			},
 			want: &cosi.DriverGrantBucketAccessResponse{
-				AccountId: accessName,
+				AccountId: maskedAccessName,
 				Credentials: map[string]*cosi.CredentialDetails{
 					"s3": {Secrets: map[string]string{
 						"accessKeyID":     "user_bucket1_user",
@@ -577,7 +579,7 @@ func TestDriverGrantBucketAccess(t *testing.T) {
 				},
 			},
 			want: &cosi.DriverGrantBucketAccessResponse{
-				AccountId: accessName,
+				AccountId: maskedAccessName,
 			},
 			setupPatches: func() *gomonkey.Patches {
 				p := gomonkey.ApplyFuncReturn(getSecret, nil, errors.New("failed to get secret"))
@@ -600,7 +602,7 @@ func TestDriverGrantBucketAccess(t *testing.T) {
 				},
 			},
 			want: &cosi.DriverGrantBucketAccessResponse{
-				AccountId: accessName,
+				AccountId: maskedAccessName,
 			},
 			setupPatches: func() *gomonkey.Patches {
 				return nil
@@ -626,7 +628,7 @@ func TestDriverGrantBucketAccess(t *testing.T) {
 				},
 			},
 			want: &cosi.DriverGrantBucketAccessResponse{
-				AccountId: accessName,
+				AccountId: maskedAccessName,
 			},
 			setupPatches: func() *gomonkey.Patches {
 				p := gomonkey.ApplyFuncReturn(getSecret, removeSecretData(utils.GLCP_USER_CLIENTID), nil)
@@ -654,7 +656,7 @@ func TestDriverGrantBucketAccess(t *testing.T) {
 				},
 			},
 			want: &cosi.DriverGrantBucketAccessResponse{
-				AccountId: accessName,
+				AccountId: maskedAccessName,
 			},
 			setupPatches: func() *gomonkey.Patches {
 				p := gomonkey.ApplyFuncReturn(getSecret, removeSecretData(utils.GLCP_USER_SECRET_KEY), nil)
@@ -682,7 +684,7 @@ func TestDriverGrantBucketAccess(t *testing.T) {
 				},
 			},
 			want: &cosi.DriverGrantBucketAccessResponse{
-				AccountId: accessName,
+				AccountId: maskedAccessName,
 			},
 			setupPatches: func() *gomonkey.Patches {
 				p := gomonkey.ApplyFuncReturn(getSecret, removeSecretData(utils.DSCC_ZONE), nil)
@@ -710,7 +712,7 @@ func TestDriverGrantBucketAccess(t *testing.T) {
 				},
 			},
 			want: &cosi.DriverGrantBucketAccessResponse{
-				AccountId: accessName,
+				AccountId: maskedAccessName,
 			},
 			setupPatches: func() *gomonkey.Patches {
 				p := gomonkey.ApplyFuncReturn(getSecret, removeSecretData(utils.ALLETRA_MP_X10K_SNO), nil)
@@ -738,7 +740,7 @@ func TestDriverGrantBucketAccess(t *testing.T) {
 				},
 			},
 			want: &cosi.DriverGrantBucketAccessResponse{
-				AccountId: accessName,
+				AccountId: maskedAccessName,
 			},
 			setupPatches: func() *gomonkey.Patches {
 				p := gomonkey.ApplyFuncReturn(getSecret, secret, nil)
@@ -765,7 +767,7 @@ func TestDriverGrantBucketAccess(t *testing.T) {
 				},
 			},
 			want: &cosi.DriverGrantBucketAccessResponse{
-				AccountId: accessName,
+				AccountId: maskedAccessName,
 			},
 			setupPatches: func() *gomonkey.Patches {
 				p := gomonkey.ApplyFuncReturn(getSecret, secret, nil)
@@ -794,7 +796,7 @@ func TestDriverGrantBucketAccess(t *testing.T) {
 				},
 			},
 			want: &cosi.DriverGrantBucketAccessResponse{
-				AccountId: accessName,
+				AccountId: maskedAccessName,
 			},
 			setupPatches: func() *gomonkey.Patches {
 				p := gomonkey.ApplyFuncReturn(getSecret, secret, nil)
@@ -823,7 +825,7 @@ func TestDriverGrantBucketAccess(t *testing.T) {
 				},
 			},
 			want: &cosi.DriverGrantBucketAccessResponse{
-				AccountId: accessName,
+				AccountId: maskedAccessName,
 			},
 			setupPatches: func() *gomonkey.Patches {
 				apiClient := iam.NewAPIClient("us1.xxxx.xxxxx.hpe.com", "dummytoken", "", "")
@@ -855,7 +857,7 @@ func TestDriverGrantBucketAccess(t *testing.T) {
 				},
 			},
 			want: &cosi.DriverGrantBucketAccessResponse{
-				AccountId: accessName,
+				AccountId: maskedAccessName,
 			},
 			setupPatches: func() *gomonkey.Patches {
 				apiClient := iam.NewAPIClient("us1.xxxx.xxxxx.hpe.com", "dummytoken", "", "")
@@ -917,6 +919,7 @@ func TestDriverRevokeBucketAccess(t *testing.T) {
 	removeSecretData := func(remField string) *v1.Secret {
 		data := map[string][]byte{utils.GLCP_USER_CLIENTID: []byte(glcpCreds.GLCPUser),
 			utils.GLCP_USER_SECRET_KEY: []byte(glcpCreds.GLCPUserSecretKey),
+			utils.GLCP_WORKSPACE_ID:    []byte(glcpCreds.GLCPWorkspaceId),
 			utils.DSCC_ZONE:            []byte(glcpCreds.DSCCZone),
 			utils.ALLETRA_MP_X10K_SNO:  []byte(glcpCreds.SystemId),
 		}
@@ -1535,6 +1538,7 @@ func createSecret(secretName string, namespace string, accessKey []byte, secretK
 	if glcpCreds != nil {
 		secret.Data[utils.GLCP_USER_CLIENTID] = []byte(glcpCreds.GLCPUser)
 		secret.Data[utils.GLCP_USER_SECRET_KEY] = []byte(glcpCreds.GLCPUserSecretKey)
+		secret.Data[utils.GLCP_WORKSPACE_ID] = []byte(glcpCreds.GLCPWorkspaceId)
 		secret.Data[utils.DSCC_ZONE] = []byte(glcpCreds.DSCCZone)
 		secret.Data[utils.ALLETRA_MP_X10K_SNO] = []byte(glcpCreds.SystemId)
 	}
@@ -1545,6 +1549,7 @@ func getIAMCredentials() utils.IAMCredentials {
 	return utils.IAMCredentials{
 		GLCPUser:          "xxxxxxx-xxx-123-3456",
 		GLCPUserSecretKey: "zzzzzrandomxxxxxxzzzzz",
+		GLCPWorkspaceId:   "dummy-workspace-id",
 		DSCCZone:          "us1.xxxx.xxxxx.hpe.com",
 		SystemId:          "DUMMY_SERIAL_NUMBER",
 	}

--- a/servers/provisioner/utils/types.go
+++ b/servers/provisioner/utils/types.go
@@ -417,3 +417,48 @@ func (r RetentionInterval) ToDaysYears() (days, years int, err error) {
 		"invalid RetentionInterval %q: unrecognised unit %q",
 		string(r), m[2])
 }
+
+// MaskName masks the UUID portion of a name (e.g. user_ba-edummy-forthe-sake-ofex-ampled918fa73)
+// keeping the prefix and last 4 characters visible, replacing the rest with 'x'.
+// Example: "user_ba-adummy-forthe-sake-ofex-mplein918fa73" -> "user_ba-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxfa73"
+func MaskName(name string) string {
+	// Find the first UUID-like pattern (8-4-4-4-12 hex chars)
+	uuidRe := regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
+	loc := uuidRe.FindStringIndex(name)
+	if loc == nil {
+		return name
+	}
+	uuid := name[loc[0]:loc[1]]
+	// Keep last 4 chars, mask the rest preserving dashes
+	masked := maskUUID(uuid)
+	return name[:loc[0]] + masked + name[loc[1]:]
+}
+
+func maskUUID(uuid string) string {
+	// UUID format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx (36 chars)
+	// Keep last 4 chars of the hex portion, mask rest with 'x'
+	runes := []rune(uuid)
+	hexCount := 0
+	totalHex := 0
+	for _, r := range runes {
+		if r != '-' {
+			totalHex++
+		}
+	}
+	visibleFromEnd := 4
+	maskCount := totalHex - visibleFromEnd
+	result := make([]rune, len(runes))
+	for i, r := range runes {
+		if r == '-' {
+			result[i] = '-'
+		} else {
+			hexCount++
+			if hexCount <= maskCount {
+				result[i] = 'x'
+			} else {
+				result[i] = r
+			}
+		}
+	}
+	return string(result)
+}

--- a/servers/provisioner/utils/types.go
+++ b/servers/provisioner/utils/types.go
@@ -422,43 +422,22 @@ func (r RetentionInterval) ToDaysYears() (days, years int, err error) {
 // keeping the prefix and last 4 characters visible, replacing the rest with 'x'.
 // Example: "user_ba-adummy-forthe-sake-ofex-mplein918fa73" -> "user_ba-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxfa73"
 func MaskName(name string) string {
-	// Find the first UUID-like pattern (8-4-4-4-12 hex chars)
-	uuidRe := regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
-	loc := uuidRe.FindStringIndex(name)
-	if loc == nil {
+	l := len(name)
+	if l <= 1 {
 		return name
 	}
-	uuid := name[loc[0]:loc[1]]
-	// Keep last 4 chars, mask the rest preserving dashes
-	masked := maskUUID(uuid)
-	return name[:loc[0]] + masked + name[loc[1]:]
+	if l > 6 {
+		return replaceWithXx(name, 2, l-4)
+	}
+	return replaceWithXx(name, 0, l-1)
 }
 
-func maskUUID(uuid string) string {
-	// UUID format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx (36 chars)
-	// Keep last 4 chars of the hex portion, mask rest with 'x'
-	runes := []rune(uuid)
-	hexCount := 0
-	totalHex := 0
-	for _, r := range runes {
-		if r != '-' {
-			totalHex++
+func replaceWithXx(str string, begin, end int) string {
+	chars := strings.Split(str, "")
+	for i, v := range chars[begin:end] {
+		if v != "-" && v != "_" {
+			chars[i+begin] = "x"
 		}
 	}
-	visibleFromEnd := 4
-	maskCount := totalHex - visibleFromEnd
-	result := make([]rune, len(runes))
-	for i, r := range runes {
-		if r == '-' {
-			result[i] = '-'
-		} else {
-			hexCount++
-			if hexCount <= maskCount {
-				result[i] = 'x'
-			} else {
-				result[i] = r
-			}
-		}
-	}
-	return string(result)
+	return strings.Join(chars, "")
 }

--- a/servers/provisioner/utils/types.go
+++ b/servers/provisioner/utils/types.go
@@ -18,6 +18,7 @@ const (
 	//KEYS in glcp secret
 	GLCP_USER_CLIENTID   = "glcpUserClientId"
 	GLCP_USER_SECRET_KEY = "glcpUserSecretKey"
+	GLCP_WORKSPACE_ID    = "glcpWorkspaceId"
 	GLCP_COMMON_CLOUD    = "GLCP_COMMON_CLOUD"
 	DSCC_ZONE            = "dsccZone"
 	ALLETRA_MP_X10K_SNO  = "clusterSerialNumber"
@@ -31,6 +32,7 @@ const (
 type IAMCredentials struct {
 	GLCPUser          string
 	GLCPUserSecretKey string
+	GLCPWorkspaceId   string
 	GLCPCommonCloud   string
 	DSCCZone          string
 	SystemId          string

--- a/servers/provisioner/utils/types_test.go
+++ b/servers/provisioner/utils/types_test.go
@@ -407,3 +407,90 @@ func TestBucketRequest_WirePayload(t *testing.T) {
 		}
 	})
 }
+
+func TestMaskName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "typical user name with UUID",
+			input: "user_ba-edummy-forthe-sake-ofex-ampled918fa73",
+			want:  "usxx_xx-xxxxxx-xxxxxx-xxxx-xxxx-xxxxxxxxxfa73",
+		},
+		{
+			name:  "short string exactly 4 chars",
+			input: "abcd",
+			want:  "xxxd",
+		},
+		{
+			name:  "5 chars masks all but last",
+			input: "abcde",
+			want:  "xxxxe",
+		},
+		{
+			name:  "6 chars masks all but last",
+			input: "abcdef",
+			want:  "xxxxxf",
+		},
+		{
+			name:  "7 chars keeps first 2 and last 4",
+			input: "abcdefg",
+			want:  "abxdefg",
+		},
+		{
+			name:  "short string 3 chars",
+			input: "abc",
+			want:  "xxc",
+		},
+		{
+			name:  "short string 2 chars",
+			input: "ab",
+			want:  "xb",
+		},
+		{
+			name:  "single char",
+			input: "a",
+			want:  "a",
+		},
+		{
+			name:  "preserves hyphens in long string",
+			input: "a-b-c-d-e",
+			want:  "a-x-x-d-e",
+		},
+		{
+			name:  "preserves underscores in long string",
+			input: "a_b_c_d_e",
+			want:  "a_x_x_d_e",
+		},
+		{
+			name:  "prefix with underscore",
+			input: "acp_12345678",
+			want:  "acx_xxxx5678",
+		},
+		{
+			name:  "all hyphens preserved",
+			input: "aa----bb",
+			want:  "aa----bb",
+		},
+		{
+			name:  "numeric string",
+			input: "1234567890",
+			want:  "12xxxx7890",
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MaskName(tt.input)
+			if got != tt.want {
+				t.Errorf("MaskName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Code**
1. Added buildTokenUrl() method that constructs the token URL based on whether a workspace ID is provided — uses the new [/authorization/v2/oauth2/{workspaceId}/token] endpoint (GreenAuth) or falls back to the legacy [/as/token.oauth2] path.
2. Added [GLCP_ACCESS_ENDPOINT_PREFIX] and [GLCP_ACCESS_ENDPOINT_SUFFIX] constants for the new auth endpoint.
3. Enhanced UserExists() and CreateS3User() to log HTTP response body on errors, including a specific message for [DOWNSTREAM_SERVICE_ERROR] guiding users to verify GLCP credentials, workspace, and [GLCP_COMMON_CLOUD].
4. Added MaskName() utility that masks UUID portions in user/policy names (e.g., user_ba-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxfa73).

**Script**
1. scripts/cosi_secret/hpe_create_cosi_secret.sh support in taking workspace id & creating secret with the new input.
2. Fixed validation to accept 3 GLCP credentials (clientId, secretKey, workspaceId) instead of 2.

**Unit Tests**
1. Added [Test_buildTokenUrl] covering both workspace-based and legacy URL construction.