### PR TITLE
Run COSI driver container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1742914212
 LABEL name="HPE COSI Driver for Kubernetes" \
     maintainer="HPE Storage" \
     vendor="HPE" \
-    version="1.0.0" \
+    version="2.0.0" \
     summary="HPE COSI Driver for Kubernetes" \
     description="The HPE COSI Driver for Kubernetes enables container orchestrators to manage the life-cycle of object storage resources." \
     io.k8s.display-name="HPE COSI Driver for Kubernetes" \
@@ -41,6 +41,11 @@ LABEL name="HPE COSI Driver for Kubernetes" \
 
 COPY LICENSE /licenses/
 
+RUN echo "cosi-driver:x:1000:1000::/home/cosi-driver:/sbin/nologin" >> /etc/passwd && \
+    echo "cosi-driver:x:1000:" >> /etc/group
+
 COPY --from=build /usr/src/hpe-cosi-driver/bin/cosi-driver cosi-driver
+
+USER 1000:1000
 
 ENTRYPOINT ["/cosi-driver"]

--- a/main.go
+++ b/main.go
@@ -129,6 +129,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Set socket permissions to allow the sidecar (running as a different UID) to connect.
+    // Unix domain sockets require write permission for clients to connect.
+    if err := os.Chmod(url.Path, 0666); err != nil {
+        log.Error(err, "failed to set socket permissions", "path", url.Path)
+        os.Exit(1)
+    }
+
 	// Start serving requests on the socket
 	err = server.Serve(lis)
 	if err != nil {


### PR DESCRIPTION
Problem:
- COSI Helm chart fails on OpenShift: hardcoded runAsUser/fsGroup (1000/2000)
  violates restricted-v2 SCC namespace UID range
- COSI driver image runs as root — requires Helm chart to hardcode runAsUser
  as a workaround

Helm chart fix (separate change):
- Removed hardcoded UID/GID from pod securityContext
- Made podSecurityContext/containerSecurityContext configurable via values.yaml
- Defaults satisfy both K8s restricted PSA and OpenShift restricted-v2 SCC
- Temporary runAsUser: 1000 still needed until image is fixed"
https://github.com/hpe-storage/co-deployments/pull/460 

This change (Dockerfile):
- Added non-root user (UID 1000) via direct /etc/passwd and /etc/group entries
- No package installs needed — works with UBI-minimal as-is
- Set USER 1000:1000 to run container process as non-root

Benefits:
- Helm chart can drop temporary runAsUser, rely on runAsNonRoot: true only
- OpenShift injects namespace-appropriate UID automatically via SCC
- Works on both Kubernetes and OpenShift without overrides
- Smaller image — no shadow-utils install/remove cycle
- COSI driver only does gRPC + API calls, no root privileges needed

Reference: https://jira.storage.hpecorp.net/browse/AS-222433