### PR TITLE
 Allow bucket locking without retention mode and period

### DIFF
--- a/servers/provisioner/provisioner.go
+++ b/servers/provisioner/provisioner.go
@@ -472,8 +472,8 @@ func validateBucketSemantics(versioning, locking utils.Feature,
 		return errors.New("Invalid bucket parameters: object locking requires versioning; enable versioning in BucketClass and recreate BucketClaim")
 	case hasRetention && locking != utils.FeatureEnabled:
 		return errors.New("Invalid bucket parameters: retentionMode and defaultRetentionInterval require object locking; enable locking in BucketClass and recreate BucketClaim")
-	case locking == utils.FeatureEnabled && (retentionMode == "" || interval == ""):
-		return errors.New("Invalid bucket parameters: object locking requires retentionMode and defaultRetentionInterval; set both in BucketClass and recreate BucketClaim")
+	case retentionMode != "" && interval == "", retentionMode == "" && interval != "":
+		return errors.New("Invalid bucket parameters: retentionMode and defaultRetentionInterval must both be set or both be omitted")
 	}
 	return nil
 }

--- a/servers/provisioner/provisioner_test.go
+++ b/servers/provisioner/provisioner_test.go
@@ -1422,24 +1422,42 @@ func TestParseBucketParams(t *testing.T) {
 			errSubstr: "locking",
 		},
 		{
-			name: "locking=Enabled without retentionMode rejected",
+			name: "locking=Enabled without retentionMode accepted",
 			params: map[string]string{
 				"versioning":               "Enabled",
 				"locking":                  "Enabled",
 				"defaultRetentionInterval": "30d",
 			},
 			wantErr:   true,
-			errSubstr: "retentionMode",
+			errSubstr: "both be set or both be omitted",
 		},
 		{
-			name: "locking=Enabled without defaultRetentionInterval rejected",
+			name: "locking=Enabled without defaultRetentionInterval accepted",
 			params: map[string]string{
 				"versioning":    "Enabled",
 				"locking":       "Enabled",
 				"retentionMode": "GOVERNANCE",
 			},
 			wantErr:   true,
-			errSubstr: "defaultRetentionInterval",
+			errSubstr: "both be set or both be omitted",
+		},
+		{
+			name: "locking=Enabled without any retention settings accepted",
+			params: map[string]string{
+				"versioning": "Enabled",
+				"locking":    "Enabled",
+			},
+			check: func(t *testing.T, r utils.BucketRequest) {
+				if r.Locking != utils.FeatureEnabled {
+					t.Errorf("Locking = %q, want Enabled", r.Locking)
+				}
+				if r.RetentionMode != "" {
+					t.Errorf("RetentionMode = %q, want empty", r.RetentionMode)
+				}
+				if r.ObjectLockDays != 0 || r.ObjectLockYears != 0 {
+					t.Errorf("expected zero retention days/years")
+				}
+			},
 		},
 	}
 
@@ -1501,9 +1519,6 @@ func TestDriverCreateBucket_InvalidArgument(t *testing.T) {
 		}},
 		{"retention without locking", map[string]string{
 			"retentionMode": "GOVERNANCE", "defaultRetentionInterval": "30d",
-		}},
-		{"locking without retention settings", map[string]string{
-			"versioning": "Enabled", "locking": "Enabled",
 		}},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
Bucket creation via COSI failed when locking: Enabled was set without retentionMode and defaultRetentionInterval in the BucketClass. ObjectStorage supports object locking without requiring retention configuration, so the validation was relaxed to allow this. Retention parameters are now optional — when omitted, the bucket is created with locking enabled but no default retention policy. Partial retention config is still rejected.