### PR TITLE
Fix S3 user deletion post bucketaccess deletion

### DIFF
--- a/servers/provisioner/provisioner.go
+++ b/servers/provisioner/provisioner.go
@@ -227,7 +227,7 @@ func (s *Server) DriverGrantBucketAccess(ctx context.Context, req *cosi.DriverGr
 	credMap["s3"] = cred
 
 	return &cosi.DriverGrantBucketAccessResponse{
-		AccountId:   maskedBucketAccessName,
+		AccountId:   bucketAccessName,
 		Credentials: credMap,
 	}, status.Error(codes.OK, fmt.Sprintf("Bucket access granted successfully for '%s' on bucket '%s'", bucketAccessName, bucketName))
 }
@@ -240,6 +240,7 @@ func (s *Server) DriverRevokeBucketAccess(ctx context.Context, req *cosi.DriverR
 
 	bucketName := req.BucketId
 	accessName := req.AccountId
+	s.log.Info("Revoking bucket access", "bucketName", bucketName, "accountName", accessName)
 	userName := utils.USER_PREFIX + accessName
 	policyName := utils.ACCESS_POLICY_PREFIX + accessName
 	var eMsg string

--- a/servers/provisioner/provisioner.go
+++ b/servers/provisioner/provisioner.go
@@ -240,7 +240,6 @@ func (s *Server) DriverRevokeBucketAccess(ctx context.Context, req *cosi.DriverR
 
 	bucketName := req.BucketId
 	accessName := req.AccountId
-	s.log.Info("Revoking bucket access", "bucketName", bucketName, "accountName", accessName)
 	userName := utils.USER_PREFIX + accessName
 	policyName := utils.ACCESS_POLICY_PREFIX + accessName
 	var eMsg string

--- a/servers/provisioner/provisioner_test.go
+++ b/servers/provisioner/provisioner_test.go
@@ -534,7 +534,7 @@ func TestDriverGrantBucketAccess(t *testing.T) {
 				},
 			},
 			want: &cosi.DriverGrantBucketAccessResponse{
-				AccountId: maskedAccessName,
+				AccountId: accessName,
 				Credentials: map[string]*cosi.CredentialDetails{
 					"s3": {Secrets: map[string]string{
 						"accessKeyID":     "user_bucket1_user",

--- a/servers/provisioner/utils/types.go
+++ b/servers/provisioner/utils/types.go
@@ -427,7 +427,7 @@ func MaskName(name string) string {
 		return name
 	}
 	if l > 6 {
-		return replaceWithXx(name, 2, l-4)
+		return replaceWithXx(name, 0, l-4)
 	}
 	return replaceWithXx(name, 0, l-1)
 }

--- a/servers/provisioner/utils/types_test.go
+++ b/servers/provisioner/utils/types_test.go
@@ -417,7 +417,7 @@ func TestMaskName(t *testing.T) {
 		{
 			name:  "typical user name with UUID",
 			input: "user_ba-edummy-forthe-sake-ofex-ampled918fa73",
-			want:  "usxx_xx-xxxxxx-xxxxxx-xxxx-xxxx-xxxxxxxxxfa73",
+			want:  "xxxx_xx-xxxxxx-xxxxxx-xxxx-xxxx-xxxxxxxxxfa73",
 		},
 		{
 			name:  "short string exactly 4 chars",
@@ -435,9 +435,9 @@ func TestMaskName(t *testing.T) {
 			want:  "xxxxxf",
 		},
 		{
-			name:  "7 chars keeps first 2 and last 4",
+			name:  "7 chars masks all but last 4",
 			input: "abcdefg",
-			want:  "abxdefg",
+			want:  "xxxdefg",
 		},
 		{
 			name:  "short string 3 chars",
@@ -457,27 +457,27 @@ func TestMaskName(t *testing.T) {
 		{
 			name:  "preserves hyphens in long string",
 			input: "a-b-c-d-e",
-			want:  "a-x-x-d-e",
+			want:  "x-x-x-d-e",
 		},
 		{
 			name:  "preserves underscores in long string",
 			input: "a_b_c_d_e",
-			want:  "a_x_x_d_e",
+			want:  "x_x_x_d_e",
 		},
 		{
 			name:  "prefix with underscore",
 			input: "acp_12345678",
-			want:  "acx_xxxx5678",
+			want:  "xxx_xxxx5678",
 		},
 		{
 			name:  "all hyphens preserved",
 			input: "aa----bb",
-			want:  "aa----bb",
+			want:  "xx----bb",
 		},
 		{
 			name:  "numeric string",
 			input: "1234567890",
-			want:  "12xxxx7890",
+			want:  "xxxxxx7890",
 		},
 		{
 			name:  "empty string",


### PR DESCRIPTION
Ensures the associated S3 user is properly deleted after a BucketAccess resource is removed. This change cleans up user credentials during the deletion workflow.